### PR TITLE
Add build-phase resolver

### DIFF
--- a/src/geo/map.rs
+++ b/src/geo/map.rs
@@ -12,6 +12,12 @@ pub struct Map {
 }
 
 impl Map {
+    /// Iterate through the provinces in the map. Each province will be returned exactly once,
+    /// but order is unspecified.
+    pub fn provinces(&self) -> impl Iterator<Item=&Province> {
+        self.provinces.values()
+    }
+
     /// Find a region by its canonical short name.
     pub fn find_region<'a>(&'a self, short_name: &str) -> Option<&'a Region> {
         self.regions.get(short_name)

--- a/src/geo/mod.rs
+++ b/src/geo/mod.rs
@@ -13,6 +13,6 @@ pub mod builder;
 pub use self::border::Border;
 pub use self::location::Location;
 pub use self::map::Map;
-pub use self::province::{Province, ProvinceKey};
+pub use self::province::{Province, ProvinceKey, SupplyCenter};
 pub use self::region::{Coast, Region, RegionKey, Terrain};
 pub use self::standard::standard_map;

--- a/src/geo/province.rs
+++ b/src/geo/province.rs
@@ -3,12 +3,32 @@ use crate::ShortName;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
+/// The supply-center nature of a province. This information is used in the build phase
+/// to determine how many units a nation can sustain and where new units can be built.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SupplyCenter {
+    /// The province does not grant a build to whoever controls it.
+    None,
+    /// The province grants a build to its controller, but cannot be used as a build target.
+    Neutral,
+    /// The province grants a build to its controller, and can be used as a build target by the
+    /// specified nation.
+    Home(Nation)
+}
+
 /// A controllable area of the environment.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Province {
     pub full_name: String,
     pub short_name: String,
-    pub supply_center_for: Option<Nation>,
+    pub supply_center: SupplyCenter,
+}
+
+impl Province {
+    /// Get if the province is a supply center for whoever controls it.
+    pub fn is_supply_center(&self) -> bool {
+        self.supply_center != SupplyCenter::None
+    }
 }
 
 impl ShortName for Province {

--- a/src/geo/provinces.csv
+++ b/src/geo/provinces.csv
@@ -2,25 +2,25 @@ short_name,full_name,supply_center_for
 adr,Adriatic Sea,
 aeg,Aegean Sea,
 alb,Albania,
-ank,Ankara,tur
+ank,Ankara,TUR
 apu,Apulia,
 arm,Armenia,
 bal,Baltic Sea,
 bar,Barents Sea,
 bel,Belgium,neutral
-ber,Berlin,ger
+ber,Berlin,GER
 bla,Black Sea,
-bre,Brest,fra
+bre,Brest,FRA
 boh,Bohemia,
 bot,Gulf of Bothnia,
-bud,Budapest,aus
+bud,Budapest,AUS
 bul,Bulgaria,neutral
 bur,Burgundy,
 cly,Clyde,
-con,Constantinople,tur
+con,Constantinople,TUR
 den,Denmark,neutral
 eas,Eastern Mediterranean,
-edi,Edinburgh,eng
+edi,Edinburgh,ENG
 eng,English Channel,
 fin,Finland,
 gal,Galicia,
@@ -30,48 +30,48 @@ hel,Helgoland Bight,
 hol,Holland,neutral
 ion,Ionian Sea,
 iri,Irish Sea,
-kie,Kiel,ger
-lon,London,eng
+kie,Kiel,GER
+lon,London,ENG
 lvn,Livonia,
-lvp,Liverpool,eng
+lvp,Liverpool,ENG
 lyo,Gulf of Lyon,
-mar,Marseilles,fra
+mar,Marseilles,FRA
 mao,Mid-Atlantic Ocean,
-mos,Moscow,rus
-mun,Munich,ger
+mos,Moscow,RUS
+mun,Munich,GER
 naf,North Africa,
 nao,North Atlantic,
-nap,Naples,ita
+nap,Naples,ITA
 nth,North Sea,
 nwg,Norweigian Sea,
 nwy,Norway,neutral
-par,Paris,fra
+par,Paris,FRA
 pic,Picardy,
 pie,Piedmont,
 por,Portugal,neutral
 pru,Prussia,
-rom,Rome,ita
+rom,Rome,ITA
 ruh,Ruhr Valley,
 rum,Rumania,neutral
 ser,Serbia,neutral
-sev,Sevastopol,rus
+sev,Sevastopol,RUS
 sil,Silesia,
 ska,Skagerrak,
-smy,Smyrna,tur
+smy,Smyrna,TUR
 spa,Spain,neutral
-stp,St. Petersburg,rus
+stp,St. Petersburg,RUS
 swe,Sweden,neutral
 swi,Switzerland,
 syr,Syria,
-tri,Trieste,aus
+tri,Trieste,AUS
 tun,Tunisia,neutral
 tus,Tuscany,
 tyr,Tyrolea,
 tys,Tyrhenian Sea,
 ukr,Ukraine,
-ven,Venice,ita
-vie,Vienna,aus
+ven,Venice,ITA
+vie,Vienna,AUS
 wal,Wales,
-war,Warsaw,rus
+war,Warsaw,RUS
 wes,Western Mediterranean,
 yor,York,

--- a/src/geo/standard.rs
+++ b/src/geo/standard.rs
@@ -1,6 +1,5 @@
 use crate::geo::builder::ProvinceRegistry;
-use crate::geo::{Coast, Map, Province, Terrain};
-use crate::Nation;
+use crate::geo::{Coast, Map, Province, SupplyCenter, Terrain};
 use lazy_static::lazy_static;
 
 lazy_static! {
@@ -55,18 +54,18 @@ fn province_from_line(s: &str) -> Result<Province, ()> {
         Ok(Province {
             short_name: String::from(words[0]),
             full_name: String::from(words[1]),
-            supply_center_for: nation_from_word(words[2]),
+            supply_center: supply_center_from_word(words[2]),
         })
     } else {
         Err(())
     }
 }
 
-fn nation_from_word(s: &str) -> Option<Nation> {
-    if s == "" {
-        None
-    } else {
-        Some(s.into())
+fn supply_center_from_word(s: &str) -> SupplyCenter {
+    match s {
+        "" => SupplyCenter::None,
+        "neutral" => SupplyCenter::Neutral,
+        nat => SupplyCenter::Home(nat.into()),
     }
 }
 

--- a/src/judge/build.rs
+++ b/src/judge/build.rs
@@ -1,0 +1,354 @@
+//! Resolver for build phases.
+
+use super::{MappedBuildOrder, OrderState};
+use crate::geo::{Map, ProvinceKey, RegionKey, SupplyCenter};
+use crate::order::BuildCommand;
+use crate::{Nation, ShortName, UnitType};
+use std::collections::{HashMap, HashSet};
+use std::convert::TryInto;
+
+/// The outcome of a build-turn order.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum OrderOutcome {
+    /// The build or disband order was successful, resulting in a change in units
+    /// in the world.
+    Succeeds,
+    /// A nation cannot issue "build" and "disband" commands in the same turn,
+    /// as this would constitute an illegal teleportation of power from the
+    /// disbanding region to the building region.
+    RedeploymentProhibited,
+    /// The build command was to a province where the issuing nation cannot build.
+    InvalidProvince,
+    /// The build command was to a home SC for the issuing power, but another
+    /// power currently controls it.
+    ForeignControlled,
+    /// Build failed because the target province already has a friendly unit in it.
+    OccupiedProvince,
+    /// The build command is to a region that is qualified for
+    InvalidTerrain,
+    /// Disband failed because no unit exists at that location.
+    DisbandingNonexistentUnit,
+    /// Disband failed because the issuing power does not control the unit at that location.
+    DisbandingForeignUnit,
+    /// The issuing nation has already had as many successful builds as they are allowed.
+    AllBuildsUsed,
+    /// The issuing nation has already had as many successful disbands as they are allowed.
+    AllDisbandsUsed,
+}
+
+impl From<OrderOutcome> for OrderState {
+    fn from(outcome: OrderOutcome) -> Self {
+        if outcome == OrderOutcome::Succeeds {
+            OrderState::Succeeds
+        } else {
+            OrderState::Fails
+        }
+    }
+}
+
+/// Provider for the resolver to get state about the game world that it needs to successfully
+/// judge a build phase.
+pub trait WorldState {
+    /// Get the set of nations in the game. This must include nations that issued no
+    /// orders this turn, and may include nations that have no units if those units
+    /// are entitled to build.
+    fn nations(&self) -> HashSet<&Nation>;
+    /// Get the nation with a unit _currently in_ the specified province. This should
+    /// return `None` if the province is vacant, even if it's controlled by a nation.
+    fn occupier(&self, province: &ProvinceKey) -> Option<&Nation>;
+    /// Get the number of units owned by the specified nation
+    fn unit_count(&self, nation: &Nation) -> u8;
+    /// Get the units owned by the specified nation
+    fn units(&self, nation: &Nation) -> HashSet<(UnitType, RegionKey)>;
+}
+
+/// The immutable pieces of a build-phase order resolution
+pub struct ResolverContext<'a, W: WorldState> {
+    world: &'a Map,
+    home_scs: HashMap<&'a Nation, HashSet<ProvinceKey>>,
+    ownerships: HashMap<&'a Nation, i16>,
+    last_time: &'a HashMap<ProvinceKey, Nation>,
+    this_time: &'a W,
+    orders: Vec<&'a MappedBuildOrder>,
+}
+
+impl<'a, W: WorldState> ResolverContext<'a, W> {
+    /// Create a new context for resolution.
+    ///
+    /// # First Winter
+    /// The first build phase of the game should pass the initial supply center ownerships to
+    /// `last_time` to ensure the resolver knows never-since-occupied home SCs belong to their
+    /// home power.
+    pub fn new(
+        world: &'a Map,
+        last_time: &'a HashMap<ProvinceKey, Nation>,
+        this_time: &'a W,
+        orders: Vec<&'a MappedBuildOrder>,
+    ) -> Self {
+        if last_time.is_empty() {
+            panic!("At least one supply center must have been owned by at least one nation. Did you forget to pass the initial world state?");
+        }
+
+        let mut home_scs = HashMap::with_capacity(25);
+        let mut ownerships = HashMap::new();
+
+        // Figure out who owns what and where nations are allowed to build.
+        for province in world.provinces().filter(|p| p.is_supply_center()) {
+            if let SupplyCenter::Home(nat) = &province.supply_center {
+                home_scs
+                    .entry(nat)
+                    .or_insert_with(HashSet::new)
+                    .insert(province.into());
+            }
+
+            let key = ProvinceKey::from(province);
+            if let Some(nation) = this_time.occupier(&key).or_else(|| last_time.get(&key)) {
+                *ownerships.entry(nation).or_insert(0) += 1;
+            }
+        }
+
+        Self {
+            world,
+            home_scs,
+            ownerships,
+            last_time,
+            this_time,
+            orders,
+        }
+    }
+
+    pub fn current_owner(&'a self, province: &ProvinceKey) -> Option<&'a Nation> {
+        self.this_time
+            .occupier(province)
+            .or_else(|| self.last_time.get(province))
+    }
+
+    pub fn resolve(&'a self) -> Outcome<'a> {
+        Resolution::new(self).resolve(self)
+    }
+}
+
+struct Resolution<'a> {
+    deltas: HashMap<&'a Nation, (BuildCommand, i16)>,
+    state: HashMap<&'a MappedBuildOrder, OrderOutcome>,
+    civil_disorder: HashSet<(UnitType, RegionKey)>,
+    final_units: HashMap<&'a Nation, HashSet<(UnitType, RegionKey)>>,
+}
+
+impl<'a> Resolution<'a> {
+    pub fn new<W: WorldState>(context: &'a ResolverContext<W>) -> Self {
+        let final_units = context
+            .this_time
+            .nations()
+            .into_iter()
+            .map(|nation| (nation, context.this_time.units(nation)))
+            .collect();
+
+        let deltas = context
+            .ownerships
+            .iter()
+            .filter_map(|(&nation, ownerships)| {
+                let adjustment = ownerships - context.this_time.unit_count(nation) as i16;
+                match adjustment {
+                    0 => None,
+                    x if x > 0 => Some((nation, (BuildCommand::Build, x))),
+                    x => Some((nation, (BuildCommand::Disband, -x))),
+                }
+            })
+            .collect();
+
+        Resolution {
+            deltas,
+            state: HashMap::with_capacity(context.orders.len()),
+            civil_disorder: HashSet::new(),
+            final_units,
+        }
+    }
+
+    pub fn resolve(mut self, context: &'a ResolverContext<impl WorldState>) -> Outcome<'a> {
+        for order in &context.orders {
+            self.resolve_order(context, order);
+        }
+
+        for (nation, delta) in &mut self.deltas {
+            if delta.0 == BuildCommand::Build || delta.1 == 0 {
+                continue;
+            }
+
+            let usize_delta: usize = delta.1.try_into().unwrap();
+            let units = self.final_units.remove(nation).unwrap();
+
+            for unit in units.clone().into_iter().take(usize_delta) {
+                self.civil_disorder.insert(unit);
+            }
+
+            self.final_units
+                .insert(nation, units.into_iter().skip(usize_delta).collect());
+        }
+
+        Outcome {
+            orders: self.state,
+            final_units: self.final_units,
+            civil_disorder: self.civil_disorder,
+        }
+    }
+
+    fn resolve_order(
+        &mut self,
+        context: &'a ResolverContext<impl WorldState>,
+        order: &'a MappedBuildOrder,
+    ) -> OrderOutcome {
+        use self::OrderOutcome::*;
+
+        // We already know the answer to this one
+        if let Some(outcome) = self.state.get(order) {
+            return *outcome;
+        }
+
+        let mut delta = if let Some(delta) = self.deltas.get_mut(&order.nation) {
+            delta
+        } else {
+            return self.resolve_as(order, RedeploymentProhibited);
+        };
+
+        // A power is only allowed to build or disband in a given turn, not both
+        if delta.0 != order.command {
+            return self.resolve_as(order, RedeploymentProhibited);
+        }
+
+        let adjudication = adjudicate(context, order);
+
+        if adjudication != OrderOutcome::Succeeds {
+            return self.resolve_as(order, adjudication);
+        }
+
+        match order.command {
+            BuildCommand::Build => {
+                if delta.1 == 0 {
+                    return self.resolve_as(order, AllBuildsUsed);
+                }
+
+                delta.1 -= 1;
+
+                self.final_units
+                    .entry(&order.nation)
+                    .or_insert_with(HashSet::new)
+                    .insert((order.unit_type, order.region.clone()));
+
+                self.resolve_as(order, Succeeds)
+            }
+            BuildCommand::Disband => {
+                if delta.1 == 0 {
+                    return self.resolve_as(order, AllDisbandsUsed);
+                }
+
+                delta.1 -= 1;
+
+                self.final_units
+                    .entry(&order.nation)
+                    .or_insert_with(HashSet::new)
+                    .remove(&(order.unit_type, order.region.clone()));
+
+                self.resolve_as(order, Succeeds)
+            }
+        }
+    }
+
+    fn resolve_as(
+        &mut self,
+        order: &'a MappedBuildOrder,
+        resolution: OrderOutcome,
+    ) -> OrderOutcome {
+        self.state.insert(order, resolution);
+        resolution
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Outcome<'a> {
+    pub orders: HashMap<&'a MappedBuildOrder, OrderOutcome>,
+    pub civil_disorder: HashSet<(UnitType, RegionKey)>,
+    pub final_units: HashMap<&'a Nation, HashSet<(UnitType, RegionKey)>>,
+}
+
+/// Rulebook function for build-phase adjudication. This function does not worry about order quantities,
+/// and just focuses on whether or not a given build or disband command is otherwise valid.
+fn adjudicate(
+    context: &ResolverContext<impl WorldState>,
+    order: &MappedBuildOrder,
+) -> OrderOutcome {
+    use self::OrderOutcome::*;
+    let province = order.region.province();
+
+    match order.command {
+        BuildCommand::Build => {
+            if !context
+                .home_scs
+                .get(&order.nation)
+                .expect("Every nation should have home SCs")
+                .contains(province)
+            {
+                return InvalidProvince;
+            }
+
+            if Some(&order.nation) != context.current_owner(province) {
+                return ForeignControlled;
+            }
+
+            if context.this_time.occupier(province).is_some() {
+                return OccupiedProvince;
+            }
+
+            let region = if let Some(region) = context.world.find_region(&order.region.short_name())
+            {
+                region
+            } else {
+                return InvalidProvince;
+            };
+
+            if !order.unit_type.can_occupy(region.terrain()) {
+                return InvalidTerrain;
+            }
+
+            Succeeds
+        }
+        BuildCommand::Disband => match context.this_time.occupier(province) {
+            None => DisbandingNonexistentUnit,
+            Some(nation) if &order.nation != nation => DisbandingForeignUnit,
+            _ => Succeeds,
+        },
+    }
+}
+
+/// Convert a map into an initial ownership state where each nation owns their home
+/// supply centers and all other supply centers are unowned.
+pub fn to_initial_ownerships(map: &Map) -> HashMap<ProvinceKey, Nation> {
+    map.provinces()
+        .filter_map(|province| {
+            if let SupplyCenter::Home(nat) = &province.supply_center {
+                Some((province.into(), nat.clone()))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::to_initial_ownerships;
+    use crate::geo::{standard_map, ProvinceKey};
+    use crate::Nation;
+
+    #[test]
+    fn to_initial_ownerships_for_standard_map() {
+        let ownerships = to_initial_ownerships(standard_map());
+
+        assert_eq!(
+            Some(&Nation::from("AUS")),
+            ownerships.get(&ProvinceKey::from("bud"))
+        );
+
+        assert_eq!(None, ownerships.get(&ProvinceKey::from("bel")));
+    }
+}

--- a/src/judge/mod.rs
+++ b/src/judge/mod.rs
@@ -1,5 +1,6 @@
 //! Contains the logic needed to adjudicate a turn.
 
+pub mod build;
 mod calc;
 mod convoy;
 mod outcome;
@@ -17,10 +18,11 @@ pub use self::state_type::{OccupationOutcome, OrderState};
 pub use self::resolver::{Adjudicate, ResolverContext, ResolverState};
 pub use self::rulebook::Rulebook;
 use crate::geo::{Border, Map, RegionKey, Terrain};
-use crate::order::{MainCommand, Order};
+use crate::order::{BuildOrder, MainCommand, Order};
 use crate::UnitType;
 
 pub type MappedMainOrder = Order<RegionKey, MainCommand<RegionKey>>;
+pub type MappedBuildOrder = BuildOrder<RegionKey>;
 
 /// Adjudicate a set of orders
 pub fn adjudicate<O: IntoIterator<Item = MappedMainOrder>>(


### PR DESCRIPTION
This enables the crate to adjudicate build phases, though at the moment it requires someone to externally provide a `WorldState` implementation.