### PR TITLE
Fix warnings that panic! msg is not string literal

### DIFF
--- a/diplomacy/src/geo/standard.rs
+++ b/diplomacy/src/geo/standard.rs
@@ -22,7 +22,7 @@ fn load_standard() -> Map {
                 .register(prov)
                 .expect("standard map shouldn't have issues");
         } else {
-            panic!(format!("Failed registering province: {}", line))
+            panic!("Failed registering province: {}", line)
         }
     }
 
@@ -32,7 +32,7 @@ fn load_standard() -> Map {
         if let Ok((prov, coast, terrain)) = region_from_line(line) {
             region_reg.register(prov, coast, terrain).unwrap();
         } else {
-            panic!(format!("Failed registering region: {}", line))
+            panic!("Failed registering region: {}", line)
         }
     }
 

--- a/diplomacy/tests/util.rs
+++ b/diplomacy/tests/util.rs
@@ -128,12 +128,12 @@ macro_rules! judge_retreat {
 
 pub fn ord(s: &str) -> MappedMainOrder {
     s.parse()
-        .unwrap_or_else(|_| panic!(format!("'{}' should be a valid order", s)))
+        .unwrap_or_else(|_| panic!("'{}' should be a valid order", s))
 }
 
 pub fn retreat_ord(s: &str) -> MappedRetreatOrder {
     s.parse()
-        .unwrap_or_else(|_| panic!(format!("'{}' should be a valid order", s)))
+        .unwrap_or_else(|_| panic!("'{}' should be a valid order", s))
 }
 
 pub fn get_results(orders: Vec<&str>) -> HashMap<MappedMainOrder, OrderState> {


### PR DESCRIPTION
```
warning: panic message is not a string literal
      --> diplomacy/src/geo/standard.rs:25:20
       |
    25 |             panic!(format!("Failed registering province: {}", line))
       |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
       = note: `#[warn(non_fmt_panics)]` on by default
       = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
       = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
       = note: the `panic!()` macro supports formatting, so there's no need for the `format!()` macro here
    help: remove the `format!(..)` macro call
       |
    25 -             panic!(format!("Failed registering province: {}", line))
    25 +             panic!("Failed registering province: {}", line)
       |
    25 +             panic!("Failed registering province: {}", line)
    warning: panic message is not a string literal
      --> diplomacy/src/geo/standard.rs:35:20
       |
    35 |             panic!(format!("Failed registering region: {}", line))
       |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       |
       = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
       = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
       = note: the `panic!()` macro supports formatting, so there's no need for the `format!()` macro here
    help: remove the `format!(..)` macro call
       |
    35 -             panic!(format!("Failed registering region: {}", line))
    35 +             panic!("Failed registering region: {}", line)
       |

    warning: `diplomacy` (lib) generated 2 warnings
    warning: panic message is not a string literal
       --> diplomacy/tests/./util.rs:131:36
        |
    131 |         .unwrap_or_else(|_| panic!(format!("'{}' should be a valid order", s)))
        |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |
        = note: `#[warn(non_fmt_panics)]` on by default
        = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
        = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
        = note: the `panic!()` macro supports formatting, so there's no need for the `format!()` macro here
    help: remove the `format!(..)` macro call
        |
    131 -         .unwrap_or_else(|_| panic!(format!("'{}' should be a valid order", s)))
    131 +         .unwrap_or_else(|_| panic!("'{}' should be a valid order", s))
        |

    warning: panic message is not a string literal
       --> diplomacy/tests/./util.rs:136:36
        |
    136 |         .unwrap_or_else(|_| panic!(format!("'{}' should be a valid order", s)))
        |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |
        = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
        = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
        = note: the `panic!()` macro supports formatting, so there's no need for the `format!()` macro here
    help: remove the `format!(..)` macro call
        |
    136 -         .unwrap_or_else(|_| panic!(format!("'{}' should be a valid order", s)))
    136 +         .unwrap_or_else(|_| panic!("'{}' should be a valid order", s))
        |
```