### PR TITLE
Make JSON representation of DATC

### DIFF
--- a/json_tests/Cargo.toml
+++ b/json_tests/Cargo.toml
@@ -8,5 +8,7 @@ description = "JSON serialization tests for diplomacy crate"
 [dependencies]
 anyhow = "1.0.86"
 diplomacy = { version = "0.1.3", path = "../diplomacy", features = ["serde"] }
+indexmap = { version = "2.10.0", features = ["serde"] }
 serde = { version = "1.0.202", features = ["derive"] }
 serde_json = "1.0.117"
+serde_with = { version = "3.14.0", features = ["macros"] }

--- a/json_tests/datc.json
+++ b/json_tests/datc.json
@@ -1,0 +1,1968 @@
+{
+    "$schema": "./tests.schema.json",
+    "cases": [
+        {
+            "name": "t6a01_move_to_non_neighbor_fails",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.A.1",
+            "phase": "Main",
+            "orders": { "ENG: F nth -> pic": "Fails" }
+        },
+        {
+            "name": "t6a02_move_army_to_sea",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.A.2",
+            "phase": "Main",
+            "orders": { "ENG: A lvp -> iri": "Fails" }
+        },
+        {
+            "name": "t6a03_move_fleet_to_land",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.A.3",
+            "phase": "Main",
+            "orders": { "GER: F kie -> mun": "Fails" }
+        },
+        {
+            "name": "t6a04_move_to_own_sector",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.A.4",
+            "phase": "Main",
+            "orders": { "GER: F kie -> kie": "Fails" }
+        },
+        {
+            "name": "t6a05_move_to_own_sector_with_convoy",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.A.5",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nth convoys yor -> yor": null,
+                "ENG: A yor -> yor": "Fails",
+                "ENG: A lvp supports A yor -> yor": "Succeeds",
+                "GER: F lon -> yor": "Succeeds",
+                "GER: A wal supports F lon -> yor": "Succeeds"
+            }
+        },
+        {
+            "name": "t6a06_ordering_a_unit_of_another_country",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.A.6",
+            "phase": "Main",
+            "starting_state": ["ENG: F lon"],
+            "orders": {
+                "GER: F lon -> nth": "Fails"
+            }
+        },
+        {
+            "name": "t6a07_only_armies_can_be_convoyed",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.A.7",
+            "phase": "Main",
+            "orders": {
+                "ENG: F lon -> bel": "Fails",
+                "ENG: F nth convoys lon -> bel": null
+            }
+        },
+        {
+            "name": "t6a08_support_to_hold_yourself_is_not_possible",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.A.8",
+            "phase": "Main",
+            "orders": {
+                "ITA: A ven -> tri": "Succeeds",
+                "ITA: A tyr supports A ven -> tri": "Succeeds",
+                "AUS: F tri supports F tri": "Fails"
+            }
+        },
+        {
+            "name": "t6a09_fleets_must_follow_coast_if_not_on_sea",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.A.9",
+            "phase": "Main",
+            "orders": { "ITA: F rom -> ven": "Fails" }
+        },
+        {
+            "name": "t6a10_support_on_unreachable_destination_not_possible",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.A.10",
+            "phase": "Main",
+            "orders": {
+                "AUS: A ven holds": "Succeeds",
+                "ITA: F rom supports A apu -> ven": null,
+                "ITA: A apu -> ven": "Fails"
+            }
+        },
+        {
+            "name": "t6a11_simple_bounce",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.A.11",
+            "phase": "Main",
+            "orders": {
+                "AUS: A vie -> tyr": "Fails",
+                "ITA: A ven -> tyr": "Fails"
+            }
+        },
+        {
+            "name": "t6a12_bounce_of_three_units",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.A.12",
+            "phase": "Main",
+            "orders": {
+                "AUS: A vie -> tyr": "Fails",
+                "ITA: A ven -> tyr": "Fails",
+                "GER: A mun -> tyr": "Fails"
+            }
+        },
+        {
+            "name": "t6b01_moving_without_required_coast_fails",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.B.1",
+            "phase": "Main",
+            "orders": { "FRA: F por -> spa": "Fails" }
+        },
+        {
+            "name": "t6b02_moving_with_unspecified_coast_when_coast_is_not_necessary",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.B.2",
+            "phase": "Main",
+            "orders": { "FRA: F gas -> spa": "Fails" }
+        },
+        {
+            "name": "t6b03_moving_with_wrong_coast_when_coast_is_not_necessary",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.B.3",
+            "phase": "Main",
+            "orders": { "FRA: F gas -> spa(sc)": "Fails" }
+        },
+        {
+            "name": "t6b04_support_to_unreachable_coast_allowed",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.B.4",
+            "phase": "Main",
+            "orders": {
+                "FRA: F gas -> spa(nc)": "Succeeds",
+                "FRA: F mar supports F gas -> spa(nc)": null,
+                "ITA: F wes -> spa(sc)": "Fails"
+            }
+        },
+        {
+            "name": "t6b05_support_from_unreachable_coast_not_allowed",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.B.5",
+            "phase": "Main",
+            "orders": {
+                "FRA: F mar -> lyo": "Fails",
+                "FRA: F spa(nc) supports F mar -> lyo": null,
+                "ITA: F lyo holds": "Succeeds"
+            }
+        },
+        {
+            "name": "t6b06_support_can_be_cut_with_other_coast",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.B.6",
+            "phase": "Main",
+            "orders": {
+                "ENG: F iri supports F nao -> mao": "Succeeds",
+                "ENG: F nao -> mao": "Succeeds",
+                "FRA: F spa(nc) supports F mao": "Fails",
+                "FRA: F mao holds": "Fails",
+                "ITA: F lyo -> spa(sc)": "Fails"
+            }
+        },
+        {
+            "name": "t6b07_supporting_with_unspecified_coast",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.B.7",
+            "todo": "Region-level precision is the caller's responsibility"
+        },
+        {
+            "name": "t6b08_supporting_with_unspecified_coast_when_only_one_coast_is_possible",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.B.8",
+            "todo": "Region-level precision is the caller's responsibility"
+        },
+        {
+            "name": "t6b09_supporting_with_wrong_coast",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.B.9",
+            "phase": "Main",
+            "orders": {
+                "FRA: F por Supports F mao -> spa(nc)": null,
+                "FRA: F mao -> spa(sc)": "Fails",
+                "ITA: F lyo Supports F wes -> spa(sc)": null,
+                "ITA: F wes -> spa(sc)": "Succeeds"
+            }
+        },
+        {
+            "name": "t6b10_unit_ordered_with_wrong_coast",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.B.10",
+            "phase": "Main",
+            "starting_state": ["FRA: F spa(sc)"],
+            "orders": {
+                "FRA: F spa(nc) -> lyo": "Fails"
+            },
+            "errata": "Region-level precision is the caller's responsibility"
+        },
+        {
+            "name": "t6b11_coast_can_not_be_ordered_to_change",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.B.11",
+            "phase": "Main",
+            "starting_state": ["FRA: F spa(nc)"],
+            "orders": {
+                "FRA: F spa(sc) -> lyo": "Fails"
+            }
+        },
+        {
+            "name": "t6b12_army_movement_with_coastal_specification",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.B.12",
+            "phase": "Main",
+            "orders": {
+                "FRA: A gas -> spa(nc)": "Fails"
+            },
+            "errata": "This sort of order correction is the responsibility of this library's caller."
+        },
+        {
+            "name": "t6b13_coastal_crawl_not_allowed",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.B.13",
+            "phase": "Main",
+            "orders": {
+                "TUR: F bul(sc) -> con": "Fails",
+                "TUR: F con -> bul(ec)": "Fails"
+            }
+        },
+        {
+            "name": "t6b14_building_with_unspecified_coast",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.B.14",
+            "phase": "Build",
+            "orders": {
+                "RUS: F stp build": "Fails"
+            }
+        },
+        {
+            "name": "t6b15_supporting_foreign_unit_with_unspecified_coast",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.B.15",
+            "todo": "Region-level precision is the caller's responsibility"
+        },
+        {
+            "name": "t6c01_three_army_circular_movement_succeeds",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.C.1",
+            "phase": "Main",
+            "orders": {
+                "TUR: F ank -> con": "Succeeds",
+                "TUR: A con -> smy": "Succeeds",
+                "TUR: A smy -> ank": "Succeeds"
+            }
+        },
+        {
+            "name": "t6c02_three_army_circular_movement_with_support",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.C.2",
+            "phase": "Main",
+            "orders": {
+                "TUR: F ank -> con": "Succeeds",
+                "TUR: A con -> smy": "Succeeds",
+                "TUR: A smy -> ank": "Succeeds",
+                "TUR: A bul supports F ank -> con": "Succeeds"
+            }
+        },
+        {
+            "name": "t6c03_a_disrupted_three_army_circular_movement",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.C.3",
+            "phase": "Main",
+            "orders": {
+                "TUR: F ank -> con": "Fails",
+                "TUR: A bul -> con": "Fails",
+                "TUR: A smy -> ank": "Fails",
+                "TUR: A con -> smy": "Fails"
+            }
+        },
+        {
+            "name": "t6c04_a_circular_movement_with_attacked_convoy",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.C.4",
+            "phase": "Main",
+            "orders": {
+                "AUS: A tri -> ser": "Succeeds",
+                "AUS: A ser -> bul": "Succeeds",
+                "TUR: A bul -> tri": "Succeeds",
+                "TUR: F aeg convoys bul -> tri": null,
+                "TUR: F ion convoys bul -> tri": null,
+                "TUR: F adr convoys bul -> tri": null,
+                "ITA: F nap -> ion": "Fails"
+            }
+        },
+        {
+            "name": "t6c05_a_disrupted_circular_movement_due_to_dislodged_convoy",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.C.5",
+            "phase": "Main",
+            "orders": {
+                "AUS: A tri -> ser": "Fails",
+                "AUS: A ser -> bul": "Fails",
+                "TUR: A bul -> tri": "Fails",
+                "TUR: F aeg convoys bul -> tri": null,
+                "TUR: F ion convoys bul -> tri": null,
+                "TUR: F adr convoys bul -> tri": null,
+                "ITA: F nap -> ion": "Succeeds",
+                "ITA: F tun supports F nap -> ion": "Succeeds"
+            }
+        },
+        {
+            "name": "t6c06_two_armies_with_two_convoys",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.C.6",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nth convoys lon -> bel": null,
+                "ENG: A lon -> bel": "Succeeds",
+                "FRA: F eng convoys bel -> lon": null,
+                "FRA: A bel -> lon": "Succeeds"
+            }
+        },
+        {
+            "name": "t6c07_disrupted_unit_swap",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.C.7",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nth convoys lon -> bel": null,
+                "ENG: A lon -> bel": "Fails",
+                "FRA: F eng convoys bel -> lon": null,
+                "FRA: A bel -> lon": "Fails",
+                "FRA: A bur -> bel": "Fails"
+            }
+        },
+        {
+            "name": "t6c08_no_self_dislodgement_in_disrupted_circular_movement",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.C.8",
+            "phase": "Main",
+            "orders": {
+                "TUR: F con -> bla": "Fails",
+                "TUR: A bul -> con": "Fails",
+                "TUR: A smy supports A bul -> con": null,
+                "RUS: F bla -> bul(ec)": "Fails",
+                "AUS: A ser -> bul": "Fails"
+            }
+        },
+        {
+            "name": "t6c09_no_help_in_dislodgement_of_own_unit_in_disrupted_circular_movement",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.C.9",
+            "phase": "Main",
+            "orders": {
+                "TUR: F con -> bla": "Fails",
+                "TUR: A smy supports A bul -> con": null,
+                "RUS: F bla -> bul(ec)": "Fails",
+                "AUS: A ser -> bul": "Fails",
+                "AUS: A bul -> con": "Fails"
+            }
+        },
+        {
+            "name": "t6d01_supported_hold_can_prevent_dislodgement",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.1",
+            "phase": "Main",
+            "orders": {
+                "AUS: F adr supports A tri -> ven": null,
+                "AUS: A tri -> ven": "Fails",
+                "ITA: A ven hold": "Succeeds",
+                "ITA: A tyr supports A ven": null
+            }
+        },
+        {
+            "name": "t6d02_a_move_cuts_support_on_hold",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.2",
+            "phase": "Main",
+            "orders": {
+                "AUS: F adr supports A tri -> ven": null,
+                "AUS: A tri -> ven": "Succeeds",
+                "AUS: A vie -> tyr": "Fails",
+                "ITA: A ven hold": "Fails",
+                "ITA: A tyr supports A ven": null
+            }
+        },
+        {
+            "name": "t6d03_a_move_cuts_support_on_move",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.3",
+            "phase": "Main",
+            "orders": {
+                "AUS: F adr supports A tri -> ven": null,
+                "AUS: A tri -> ven": "Fails",
+                "ITA: A ven hold": "Succeeds",
+                "ITA: F ion -> adr": "Fails"
+            }
+        },
+        {
+            "name": "t6d04_support_to_hold_on_unit_supporting_a_hold_allowed",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.4",
+            "phase": "Main",
+            "orders": {
+                "GER: A ber supports F kie": null,
+                "GER: F kie supports A ber": null,
+                "RUS: F bal supports A pru -> ber": null,
+                "RUS: A pru -> ber": "Fails"
+            }
+        },
+        {
+            "name": "t6d05_support_to_hold_on_unit_supporting_a_move_allowed",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.5",
+            "phase": "Main",
+            "orders": {
+                "GER: A ber supports A mun -> sil": null,
+                "GER: F kie supports A ber": null,
+                "GER: A mun -> sil": null,
+                "RUS: F bal supports A pru -> ber": null,
+                "RUS: A pru -> ber": "Fails"
+            }
+        },
+        {
+            "name": "t6d06_support_to_hold_on_convoying_unit_allowed",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.6",
+            "phase": "Main",
+            "orders": {
+                "GER: A ber -> swe": "Succeeds",
+                "GER: F bal convoys ber -> swe": null,
+                "GER: F pru Supports F bal": null,
+                "RUS: F lvn -> bal": "Fails",
+                "RUS: F bot Supports F lvn -> bal": null
+            }
+        },
+        {
+            "name": "t6d07_support_to_hold_on_moving_unit_not_allowed",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.7",
+            "phase": "Main",
+            "orders": {
+                "GER: F bal -> swe": "Fails",
+                "GER: F pru Supports F bal": null,
+                "RUS: F lvn -> bal": "Succeeds",
+                "RUS: F bot Supports F lvn -> bal": null,
+                "RUS: A fin -> swe": "Fails"
+            }
+        },
+        {
+            "name": "t6d08_failed_convoy_can_not_receive_hold_support",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.8",
+            "phase": "Main",
+            "orders": {
+                "AUS: F ion hold": null,
+                "AUS: A ser Supports A alb -> gre": null,
+                "AUS: A alb -> gre": "Succeeds",
+                "TUR: A gre -> nap": "Fails",
+                "TUR: A bul Supports A gre": null
+            }
+        },
+        {
+            "name": "t6d09_support_to_move_on_holding_unit_not_allowed",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.9",
+            "phase": "Main",
+            "orders": {
+                "ITA: A ven -> tri": "Succeeds",
+                "ITA: A tyr supports A ven -> tri": null,
+                "AUS: A alb supports A tri -> ser": null,
+                "AUS: A tri holds": "Fails"
+            }
+        },
+        {
+            "name": "t6d10_self_dislodgment_prohibited",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.10",
+            "phase": "Main",
+            "orders": {
+                "GER: A ber Hold": "Succeeds",
+                "GER: F kie -> ber": "Fails",
+                "GER: A mun Supports F kie -> ber": null
+            }
+        },
+        {
+            "name": "t6d11_no_self_dislodgment_of_returning_unit",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.11",
+            "phase": "Main",
+            "orders": {
+                "GER: A ber -> pru": "Fails",
+                "GER: F kie -> ber": "Fails",
+                "GER: A mun Supports F kie -> ber": null,
+                "RUS: A war -> pru": "Fails"
+            }
+        },
+        {
+            "name": "t6d12_supporting_a_foreign_unit_to_dislodge_own_unit_prohibited",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.12",
+            "phase": "Main",
+            "orders": {
+                "AUS: F tri Hold": "Succeeds",
+                "AUS: A vie Supports A ven -> tri": null,
+                "ITA: A ven -> tri": "Fails"
+            }
+        },
+        {
+            "name": "t6d13_supporting_a_foreign_unit_to_dislodge_a_returning_own_unit_prohibited",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.13",
+            "phase": "Main",
+            "orders": {
+                "AUS: F tri -> adr": "Fails",
+                "AUS: A vie Supports A ven -> tri": null,
+                "ITA: A ven -> tri": "Fails",
+                "ITA: F apu -> adr": "Fails"
+            }
+        },
+        {
+            "name": "t6d14_supporting_a_foreign_unit_is_not_enough_to_prevent_dislodgement",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.14",
+            "phase": "Main",
+            "orders": {
+                "AUS: F tri Hold": "Fails",
+                "AUS: A vie Supports A ven -> tri": null,
+                "ITA: A ven -> tri": "Succeeds",
+                "ITA: A tyr Supports A ven -> tri": null,
+                "ITA: F adr Supports A ven -> tri": null
+            }
+        },
+        {
+            "name": "t6d15_defender_can_not_cut_support_for_attack_on_itself",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.15",
+            "phase": "Main",
+            "orders": {
+                "RUS: F con Supports F bla -> ank": null,
+                "RUS: F bla -> ank": "Succeeds",
+                "TUR: F ank -> con": "Fails"
+            }
+        },
+        {
+            "name": "t6d17_dislodgement_cuts_supports",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.17",
+            "phase": "Main",
+            "orders": {
+                "RUS: F con Supports F bla -> ank": "Fails",
+                "RUS: F bla -> ank": "Fails",
+                "TUR: F ank -> con": "Succeeds",
+                "TUR: A smy Supports F ank -> con": null,
+                "TUR: A arm -> ank": "Fails"
+            }
+        },
+        {
+            "name": "t6d18_a_surviving_unit_will_sustain_support",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.18",
+            "phase": "Main",
+            "orders": {
+                "RUS: F con Supports F bla -> ank": "Succeeds",
+                "RUS: F bla -> ank": "Succeeds",
+                "RUS: A bul Supports F con": "Succeeds",
+                "TUR: F ank -> con": "Fails",
+                "TUR: A smy Supports F ank -> con": "Succeeds",
+                "TUR: A arm -> ank": "Fails"
+            }
+        },
+        {
+            "name": "t6d19_even_when_surviving_is_in_alternative_way",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.19",
+            "phase": "Main",
+            "orders": {
+                "RUS: F con Supports F bla -> ank": null,
+                "RUS: F bla -> ank": "Succeeds",
+                "RUS: A smy Supports F ank -> con": null,
+                "TUR: F ank -> con": "Fails"
+            }
+        },
+        {
+            "name": "t6d20_unit_can_not_cut_support_of_its_own_country",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.20",
+            "phase": "Main",
+            "orders": {
+                "ENG: F lon Supports F nth -> eng": null,
+                "ENG: F nth -> eng": "Succeeds",
+                "ENG: A yor -> lon": "Fails",
+                "FRA: F eng Hold": "Fails"
+            }
+        },
+        {
+            "name": "t6d21_dislodging_does_not_cancel_a_support_cut",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.21",
+            "phase": "Main",
+            "orders": {
+                "AUS: F tri Hold": "Succeeds",
+                "ITA: A ven -> tri": "Fails",
+                "ITA: A tyr supports A ven -> tri": null,
+                "GER: A mun -> tyr": "Fails",
+                "RUS: A sil -> mun": "Succeeds",
+                "RUS: A ber Supports A sil -> mun": null
+            }
+        },
+        {
+            "name": "t6d22_impossible_fleet_move_can_not_be_supported",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.22",
+            "phase": "Main",
+            "orders": {
+                "GER: F kie -> mun": "Fails",
+                "GER: A bur Supports F kie -> mun": null,
+                "RUS: A mun -> kie": "Succeeds",
+                "RUS: A ber Supports A mun -> kie": null
+            }
+        },
+        {
+            "name": "t6d23_impossible_coast_move_can_not_be_supported",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.23",
+            "phase": "Main",
+            "orders": {
+                "ITA: F lyo -> spa(sc)": "Succeeds",
+                "ITA: F wes Supports F lyo -> spa(sc)": null,
+                "FRA: F spa(nc) -> lyo": "Fails",
+                "FRA: F mar Supports F spa(nc) -> lyo": null
+            }
+        },
+        {
+            "name": "t6d24_impossible_army_move_can_not_be_supported",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.24",
+            "phase": "Main",
+            "orders": {
+                "FRA: A mar -> lyo": "Fails",
+                "FRA: F spa(sc) Supports A mar -> lyo": null,
+                "ITA: F lyo Hold": "Fails",
+                "TUR: F tys Supports F wes -> lyo": null,
+                "TUR: F wes -> lyo": "Succeeds"
+            }
+        },
+        {
+            "name": "t6d25_failing_hold_support_can_be_supported",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.25",
+            "phase": "Main",
+            "orders": {
+                "GER: A ber Supports A pru": null,
+                "GER: F kie Supports A ber": null,
+                "RUS: F bal Supports A pru -> ber": null,
+                "RUS: A pru -> ber": "Fails"
+            }
+        },
+        {
+            "name": "t6d26_failing_move_support_can_be_supported",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.26",
+            "phase": "Main",
+            "orders": {
+                "GER: A ber Supports A pru -> sil": null,
+                "GER: F kie Supports A ber": null,
+                "RUS: F bal Supports A pru -> ber": null,
+                "RUS: A pru -> ber": "Fails"
+            }
+        },
+        {
+            "name": "t6d27_failing_convoy_can_be_supported",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.27",
+            "phase": "Main",
+            "orders": {
+                "ENG: F swe -> bal": "Fails",
+                "ENG: F den Supports F swe -> bal": null,
+                "GER: A ber Hold": null,
+                "RUS: F bal convoys ber -> lvn": null,
+                "RUS: F pru Supports F bal": null
+            }
+        },
+        {
+            "name": "t6d28_impossible_move_and_support",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.28",
+            "phase": "Main",
+            "orders": {
+                "AUS: A bud Supports F rum": null,
+                "RUS: F rum -> hol": null,
+                "TUR: F bla -> rum": "Fails",
+                "TUR: A bul Supports F bla -> rum": null
+            }
+        },
+        {
+            "name": "t6d29_move_to_impossible_coast_and_support",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.29",
+            "phase": "Main",
+            "orders": {
+                "AUS: A bud Supports F rum": null,
+                "RUS: F rum -> bul(sc)": null,
+                "TUR: F bla -> rum": "Fails",
+                "TUR: A bul Supports F bla -> rum": null
+            }
+        },
+        {
+            "name": "t6d30_move_without_coast_and_support",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.30",
+            "phase": "Main",
+            "orders": {
+                "ITA: F aeg Supports F con": null,
+                "RUS: F con -> bul": "Fails",
+                "TUR: F bla -> con": "Fails",
+                "TUR: A bul Supports F bla -> con": null
+            }
+        },
+        {
+            "name": "t6d31_a_tricky_impossible_support",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.31",
+            "phase": "Main",
+            "orders": {
+                "AUS: A rum -> arm": "Fails",
+                "TUR: F bla Supports A rum -> arm": null
+            }
+        },
+        {
+            "name": "t6d32_a_missing_fleet",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.32",
+            "phase": "Main",
+            "orders": {
+                "ENG: F edi Supports A lvp -> yor": null,
+                "ENG: A lvp -> yor": "Fails",
+                "FRA: F lon Supports A yor": null,
+                "GER: A yor -> hol": "Fails"
+            }
+        },
+        {
+            "name": "t6d33_unwanted_support_allowed",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.33",
+            "phase": "Main",
+            "orders": {
+                "AUS: A ser -> bud": "Succeeds",
+                "AUS: A vie -> bud": "Fails",
+                "RUS: A gal supports A ser -> bud": null,
+                "TUR: A bul -> ser": "Succeeds"
+            }
+        },
+        {
+            "name": "t6d34_support_targeting_own_area_not_allowed",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.D.34",
+            "phase": "Main",
+            "orders": {
+                "GER: A ber -> pru": "Succeeds",
+                "GER: A sil supports A ber -> pru": null,
+                "GER: F bal supports A ber -> pru": null,
+                "ITA: A pru supports A lvn -> pru": "Fails",
+                "RUS: A war supports A lvn -> pru": null,
+                "RUS: A lvn -> pru": "Fails"
+            }
+        },
+        {
+            "name": "t6e01_dislodged_unit_has_no_effect_on_attacker_area",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.E.1",
+            "phase": "Main",
+            "orders": {
+                "GER: A ber -> pru": "Succeeds",
+                "GER: F kie -> ber": "Succeeds",
+                "GER: A sil supports A ber -> pru": null,
+                "RUS: A pru -> ber": "Fails"
+            }
+        },
+        {
+            "name": "t6e02_no_self_dislodgement_in_head_to_head_battle",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.E.2",
+            "phase": "Main",
+            "orders": {
+                "GER: A ber -> kie": "Fails",
+                "GER: F kie -> ber": "Fails",
+                "GER: A mun Supports A ber -> kie": null
+            }
+        },
+        {
+            "name": "t6e03_no_help_in_dislodging_own_unit",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.E.3",
+            "phase": "Main",
+            "orders": {
+                "GER: A ber -> kie": "Fails",
+                "GER: A mun supports F kie -> ber": null,
+                "ENG: F kie -> ber": "Fails"
+            }
+        },
+        {
+            "name": "t6e04_non_dislodged_loser_has_still_effect",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.E.4",
+            "phase": "Main",
+            "orders": {
+                "GER: F hol -> nth": "Fails",
+                "GER: F hel Supports F hol -> nth": null,
+                "GER: F ska Supports F hol -> nth": null,
+                "FRA: F nth -> hol": "Fails",
+                "FRA: F bel Supports F nth -> hol": null,
+                "ENG: F edi Supports F nwg -> nth": null,
+                "ENG: F yor Supports F nwg -> nth": null,
+                "ENG: F nwg -> nth": "Fails",
+                "AUS: A kie Supports A ruh -> hol": null,
+                "AUS: A ruh -> hol": "Fails"
+            }
+        },
+        {
+            "name": "t6e05_loser_dislodged_by_another_army_has_still_effect",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.E.5",
+            "phase": "Main",
+            "orders": {
+                "GER: F hol -> nth": "Fails",
+                "GER: F hel Supports F hol -> nth": null,
+                "GER: F ska Supports F hol -> nth": null,
+                "FRA: F nth -> hol": "Fails",
+                "FRA: F bel Supports F nth -> hol": null,
+                "ENG: F edi Supports F nwg -> nth": null,
+                "ENG: F yor Supports F nwg -> nth": null,
+                "ENG: F nwg -> nth": "Succeeds",
+                "ENG: F lon Supports F nwg -> nth": null,
+                "AUS: A kie Supports A ruh -> hol": null,
+                "AUS: A ruh -> hol": "Fails"
+            }
+        },
+        {
+            "name": "t6e06_not_dislodge_because_of_own_support_has_still_effect",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.E.6",
+            "phase": "Main",
+            "orders": {
+                "GER: F hol -> nth": "Fails",
+                "GER: F hel Supports F hol -> nth": null,
+                "FRA: F nth -> hol": "Fails",
+                "FRA: F bel Supports F nth -> hol": null,
+                "FRA: F eng Supports F hol -> nth": null,
+                "AUS: A kie Supports A ruh -> hol": null,
+                "AUS: A ruh -> hol": "Fails"
+            }
+        },
+        {
+            "name": "t6e07_no_self_dislodgement_with_beleaguered_garrison",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.E.7",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nth Hold": "Succeeds",
+                "ENG: F yor Supports F nwy -> nth": null,
+                "GER: F hol Supports F hel -> nth": null,
+                "GER: F hel -> nth": "Fails",
+                "RUS: F ska Supports F nwy -> nth": null,
+                "RUS: F nwy -> nth": "Fails"
+            }
+        },
+        {
+            "name": "t6e08_no_self_dislodgement_with_beleaguered_garrison_and_head_to_head_battle",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.E.8",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nth -> nwy": "Fails",
+                "ENG: F yor Supports F nwy -> nth": null,
+                "GER: F hol Supports F hel -> nth": null,
+                "GER: F hel -> nth": "Fails",
+                "RUS: F ska Supports F nwy -> nth": null,
+                "RUS: F nwy -> nth": "Fails"
+            }
+        },
+        {
+            "name": "t6e09_almost_self_dislodgement_with_beleaguered_garrison",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.E.9",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nth -> nwg": "Succeeds",
+                "ENG: F yor Supports F nwy -> nth": null,
+                "GER: F hol Supports F hel -> nth": null,
+                "GER: F hel -> nth": "Fails",
+                "RUS: F ska Supports F nwy -> nth": null,
+                "RUS: F nwy -> nth": "Succeeds"
+            }
+        },
+        {
+            "name": "t6e10_almost_circular_movement_with_no_self_dislodgement_with_beleaguered_garrison",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.E.10",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nth -> den": "Fails",
+                "ENG: F yor Supports F nwy -> nth": null,
+                "GER: F hol Supports F hel -> nth": null,
+                "GER: F hel -> nth": "Fails",
+                "GER: F den -> hel": "Fails",
+                "RUS: F ska Supports F nwy -> nth": null,
+                "RUS: F nwy -> nth": "Fails"
+            }
+        },
+        {
+            "name": "t6e11_no_self_dislodgement_with_beleaguered_garrison_unit_swap_with_adjacent_convoying_and_two_coasts",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.E.11",
+            "phase": "Main",
+            "orders": {
+                "FRA: A spa -> por via Convoy": "Succeeds",
+                "FRA: F mao convoys spa -> por": null,
+                "FRA: F lyo Supports F por -> spa(nc)": null,
+                "GER: A mar Supports A gas -> spa": null,
+                "GER: A gas -> spa": "Fails",
+                "ITA: F por -> spa(nc)": "Succeeds",
+                "ITA: F wes Supports F por -> spa(nc)": null
+            }
+        },
+        {
+            "name": "t6e12_support_on_attack_on_own_unit_can_be_used_for_other_means",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.E.12",
+            "phase": "Main",
+            "orders": {
+                "AUS: A bud -> rum": "Fails",
+                "AUS: A ser Supports A vie -> bud": null,
+                "ITA: A vie -> bud": "Fails",
+                "RUS: A gal -> bud": "Fails",
+                "RUS: A rum Supports A gal -> bud": null
+            }
+        },
+        {
+            "name": "t6e13_three_way_beleaguered_garrison",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.E.13",
+            "phase": "Main",
+            "orders": {
+                "ENG: F edi Supports F yor -> nth": null,
+                "ENG: F yor -> nth": "Fails",
+                "FRA: F bel -> nth": "Fails",
+                "FRA: F eng Supports F bel -> nth": null,
+                "GER: F nth Hold": "Succeeds",
+                "RUS: F nwg -> nth": "Fails",
+                "RUS: F nwy Supports F nwg -> nth": null
+            }
+        },
+        {
+            "name": "t6e14_illegal_head_to_head_battle_can_still_defend",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.E.14",
+            "phase": "Main",
+            "orders": {
+                "ENG: A lvp -> edi": "Fails",
+                "RUS: F edi -> lvp": "Fails"
+            }
+        },
+        {
+            "name": "t6e15_the_friendly_head_to_head_battle",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.E.15",
+            "phase": "Main",
+            "orders": {
+                "ENG: F hol Supports A ruh -> kie": null,
+                "ENG: A ruh -> kie": "Fails",
+                "FRA: A kie -> ber": "Fails",
+                "FRA: A mun Supports A kie -> ber": null,
+                "FRA: A sil Supports A kie -> ber": null,
+                "GER: A ber -> kie": "Fails",
+                "GER: F den Supports A ber -> kie": null,
+                "GER: F hel Supports A ber -> kie": null,
+                "RUS: F bal Supports A pru -> ber": null,
+                "RUS: A pru -> ber": "Fails"
+            }
+        },
+        {
+            "name": "t6f01_no_convoy_in_coastal_areas",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.1",
+            "phase": "Main",
+            "orders": {
+                "TUR: A gre -> sev": "Fails",
+                "TUR: F aeg convoys gre -> sev": null,
+                "TUR: F con convoys gre -> sev": null,
+                "TUR: F bla convoys gre -> sev": null
+            }
+        },
+        {
+            "name": "t6f02_an_army_being_convoyed_can_bounce_as_normal",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.2",
+            "phase": "Main",
+            "orders": {
+                "ENG: F eng convoys lon -> bre": null,
+                "ENG: A lon -> bre": "Fails",
+                "FRA: A par -> bre": "Fails"
+            }
+        },
+        {
+            "name": "t6f03_an_army_being_convoyed_can_receive_support",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.3",
+            "phase": "Main",
+            "orders": {
+                "ENG: F eng convoys lon -> bre": null,
+                "ENG: A lon -> bre": "Succeeds",
+                "ENG: F mao Supports A lon -> bre": "Succeeds",
+                "FRA: A par -> bre": "Fails"
+            }
+        },
+        {
+            "name": "t6f04_an_attacked_convoy_is_not_disrupted",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.4",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nth convoys lon -> hol": null,
+                "ENG: A lon -> hol": "Succeeds",
+                "GER: F ska -> nth": "Fails"
+            }
+        },
+        {
+            "name": "t6f05_a_beleaguered_convoy_is_not_disrupted",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.5",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nth convoys lon -> hol": null,
+                "ENG: A lon -> hol": "Succeeds",
+                "FRA: F eng -> nth": "Fails",
+                "FRA: F bel Supports F eng -> nth": null,
+                "GER: F ska -> nth": "Fails",
+                "GER: F den Supports F ska -> nth": null
+            }
+        },
+        {
+            "name": "t6f06_dislodged_convoy_does_not_cut_support",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.6",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nth convoys lon -> hol": null,
+                "ENG: A lon -> hol": null,
+                "GER: A hol Supports A bel": "Succeeds",
+                "GER: A bel Supports A hol": null,
+                "GER: F hel Supports F ska -> nth": null,
+                "GER: F ska -> nth": null,
+                "FRA: A pic -> bel": "Fails",
+                "FRA: A bur Supports A pic -> bel": null
+            }
+        },
+        {
+            "name": "t6f07_dislodged_convoy_does_not_cause_contested_area",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.7",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nth convoys lon -> hol": null,
+                "ENG: A lon -> hol": "Fails",
+                "GER: F hel Supports F ska -> nth": null,
+                "GER: F ska -> nth": "Succeeds"
+            }
+        },
+        {
+            "name": "t6f08_dislodged_convoy_does_not_cause_a_bounce",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.8",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nth convoys lon -> hol": null,
+                "ENG: A lon -> hol": "Fails",
+                "GER: F hel Supports F ska -> nth": null,
+                "GER: F ska -> nth": "Succeeds",
+                "GER: A bel -> hol": "Succeeds"
+            }
+        },
+        {
+            "name": "t6f09_dislodge_of_multi_route_convoy",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.9",
+            "phase": "Main",
+            "orders": {
+                "ENG: F eng convoys lon -> bel": null,
+                "ENG: F nth convoys lon -> bel": null,
+                "ENG: A lon -> bel": "Succeeds",
+                "FRA: F bre Supports F mao -> eng": null,
+                "FRA: F mao -> eng": "Succeeds"
+            }
+        },
+        {
+            "name": "t6f10_dislodge_of_multi_route_convoy_with_foreign_fleet",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.10",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nth convoys lon -> bel": null,
+                "ENG: A lon -> bel": "Succeeds",
+                "GER: F eng convoys lon -> bel": null,
+                "FRA: F bre Supports F mao -> eng": null,
+                "FRA: F mao -> eng": "Succeeds"
+            }
+        },
+        {
+            "name": "t6f11_dislodge_of_multi_route_convoy_with_only_foreign_fleets",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.11",
+            "phase": "Main",
+            "orders": {
+                "ENG: A lon -> bel": "Succeeds",
+                "GER: F eng convoys lon -> bel": null,
+                "RUS: F nth convoys lon -> bel": null,
+                "FRA: F bre Supports F mao -> eng": null,
+                "FRA: F mao -> eng": "Succeeds"
+            }
+        },
+        {
+            "name": "t6f12_dislodged_convoying_fleet_not_on_route",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.12",
+            "phase": "Main",
+            "orders": {
+                "ENG: F eng convoys lon -> bel": null,
+                "ENG: A lon -> bel": "Succeeds",
+                "ENG: F iri convoys lon -> bel": "Fails",
+                "FRA: F nao Supports F mao -> iri": null,
+                "FRA: F mao -> iri": "Succeeds"
+            }
+        },
+        {
+            "name": "t6f13_the_unwanted_alternative",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.13",
+            "phase": "Main",
+            "orders": {
+                "ENG: A lon -> bel": "Succeeds",
+                "ENG: F nth convoys lon -> bel": null,
+                "FRA: F eng convoys lon -> bel": null,
+                "GER: F hol Supports F den -> nth": null,
+                "GER: F den -> nth": "Succeeds"
+            }
+        },
+        {
+            "name": "t6f14_simple_convoy_paradox",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.14",
+            "phase": "Main",
+            "orders": {
+                "ENG: F lon Supports F wal -> eng": null,
+                "ENG: F wal -> eng": "Succeeds",
+                "FRA: A bre -> lon": "Fails",
+                "FRA: F eng convoys bre -> lon": "Fails"
+            }
+        },
+        {
+            "name": "t6f15_simple_convoy_paradox_with_additional_convoy",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.15",
+            "phase": "Main",
+            "orders": {
+                "ENG: F lon Supports F wal -> eng": null,
+                "ENG: F wal -> eng": "Succeeds",
+                "FRA: A bre -> lon": "Fails",
+                "FRA: F eng convoys bre -> lon": null,
+                "ITA: F iri convoys naf -> wal": null,
+                "ITA: F mao convoys naf -> wal": null,
+                "ITA: A naf -> wal": "Succeeds"
+            }
+        },
+        {
+            "name": "t6f16_pandins_paradox",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.16",
+            "phase": "Main",
+            "orders": {
+                "ENG: F lon Supports F wal -> eng": null,
+                "ENG: F wal -> eng": "Fails",
+                "FRA: A bre -> lon": "Fails",
+                "FRA: F eng convoys bre -> lon": null,
+                "GER: F nth Supports F bel -> eng": null,
+                "GER: F bel -> eng": "Fails"
+            }
+        },
+        {
+            "name": "t6f17_pandins_extended_paradox",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.17",
+            "phase": "Main",
+            "orders": {
+                "ENG: F lon Supports F wal -> eng": null,
+                "ENG: F wal -> eng": "Fails",
+                "FRA: A bre -> lon": "Fails",
+                "FRA: F eng convoys bre -> lon": null,
+                "FRA: F yor Supports A bre -> lon": null,
+                "GER: F nth Supports F bel -> eng": null,
+                "GER: F bel -> eng": "Fails"
+            }
+        },
+        {
+            "name": "t6f18_betrayal_paradox",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.18",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nth convoys lon -> bel": null,
+                "ENG: A lon -> bel": "Fails",
+                "ENG: F eng Supports A lon -> bel": null,
+                "FRA: F bel Supports F nth": null,
+                "GER: F hel Supports F ska -> nth": null,
+                "GER: F ska -> nth": "Fails"
+            }
+        },
+        {
+            "name": "t6f19_multi_route_convoy_disruption_paradox",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.19",
+            "phase": "Main",
+            "orders": {
+                "FRA: A tun -> nap": "Fails",
+                "FRA: F tys convoys tun -> nap": null,
+                "FRA: F ion convoys tun -> nap": null,
+                "ITA: F nap Supports F rom -> tys": null,
+                "ITA: F rom -> tys": "Fails"
+            }
+        },
+        {
+            "name": "t6f20_unwanted_multi_route_convoy_paradox",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.20",
+            "phase": "Main",
+            "orders": {
+                "FRA: A tun -> nap": null,
+                "FRA: F tys convoys tun -> nap": null,
+                "ITA: F nap Supports F ion": null,
+                "ITA: F ion convoys tun -> nap": null,
+                "TUR: F aeg Supports F eas -> ion": null,
+                "TUR: F eas -> ion": "Succeeds"
+            }
+        },
+        {
+            "name": "t6f21_dads_army_convoy",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.21",
+            "phase": "Main",
+            "orders": {
+                "RUS: A edi Supports A nwy -> cly": null,
+                "RUS: F nwg convoys nwy -> cly": null,
+                "RUS: A nwy -> cly": null,
+                "FRA: F iri Supports F mao -> nao": null,
+                "FRA: F mao -> nao": "Succeeds",
+                "ENG: A lvp -> cly via Convoy": "Fails",
+                "ENG: F nao convoys lvp -> cly": null,
+                "ENG: F cly Supports F nao": null
+            }
+        },
+        {
+            "name": "t6f22_second_order_paradox_with_two_resolutions",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.22",
+            "phase": "Main",
+            "orders": {
+                "ENG: F edi -> nth": "Succeeds",
+                "ENG: F lon Supports F edi -> nth": null,
+                "FRA: A bre -> lon": "Fails",
+                "FRA: F eng convoys bre -> lon": "Fails",
+                "GER: F bel Supports F pic -> eng": null,
+                "GER: F pic -> eng": "Succeeds",
+                "RUS: A nwy -> bel": "Fails",
+                "RUS: F nth convoys nwy -> bel": "Fails"
+            }
+        },
+        {
+            "name": "t6f23_second_order_paradox_with_two_exclusive_convoys",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.23",
+            "phase": "Main",
+            "orders": {
+                "ENG: F edi -> nth": "Fails",
+                "ENG: F yor Supports F edi -> nth": null,
+                "FRA: A bre -> lon": "Fails",
+                "FRA: F eng convoys bre -> lon": null,
+                "GER: F bel Supports F eng": null,
+                "GER: F lon Supports F nth": null,
+                "ITA: F mao -> eng": "Fails",
+                "ITA: F iri Supports F mao -> eng": null,
+                "RUS: A nwy -> bel": "Fails",
+                "RUS: F nth convoys nwy -> bel": null
+            }
+        },
+        {
+            "name": "t6f24_second_order_paradox_with_no_resolution",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.24",
+            "phase": "Main",
+            "orders": {
+                "ENG: F edi -> nth": null,
+                "ENG: F lon Supports F edi -> nth": null,
+                "ENG: F iri -> eng": null,
+                "ENG: F mao Supports F iri -> eng": null,
+                "FRA: A bre -> lon": "Fails",
+                "FRA: F eng convoys bre -> lon": null,
+                "FRA: F bel Supports F eng": null,
+                "RUS: A nwy -> bel": "Fails",
+                "RUS: F nth convoys nwy -> bel": "Fails"
+            }
+        },
+        {
+            "name": "t6f25_cut_support_last",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.F.25",
+            "phase": "Main",
+            "orders": {
+                "GER: A ruh -> bel": "Fails",
+                "GER: A hol Supports A ruh -> bel": null,
+                "GER: A den -> nwy": null,
+                "GER: F ska Convoys den -> nwy": null,
+                "GER: A fin Supports A den -> nwy": null,
+                "ENG: A yor -> hol": "Succeeds",
+                "ENG: F nth Convoys yor -> hol": null,
+                "ENG: F hel Supports A yor -> hol": null,
+                "ENG: A bel hold": null,
+                "RUS: F nwg -> nth": "Fails",
+                "RUS: F nwy Supports F nwg -> nth": null,
+                "RUS: F swe -> ska": "Fails"
+            }
+        },
+        {
+            "name": "t6g01_two_units_can_swap_provinces_by_convoy",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.1",
+            "phase": "Main",
+            "orders": {
+                "ENG: A nwy -> swe": "Succeeds",
+                "ENG: F ska Convoys nwy -> swe": null,
+                "RUS: A swe -> nwy": "Succeeds"
+            }
+        },
+        {
+            "name": "t6g02_kidnapping_an_army",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.2",
+            "phase": "Main",
+            "orders": {
+                "ENG: A nwy -> swe": "Succeeds",
+                "RUS: F swe -> nwy": "Succeeds",
+                "GER: F ska convoys nwy -> swe": null
+            }
+        },
+        {
+            "name": "t6g03_unwanted_disrupted_convoy_to_adjacent_province",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.3",
+            "phase": "Main",
+            "orders": {
+                "FRA: F bre -> eng": "Succeeds",
+                "FRA: A pic -> bel": "Succeeds",
+                "FRA: A bur Supports A pic -> bel": null,
+                "FRA: F mao Supports F bre -> eng": null,
+                "ENG: F eng convoys pic -> bel": null
+            }
+        },
+        {
+            "name": "t6g04_unwanted_disrupted_convoy_to_adjacent_province_and_opposite_move",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.4",
+            "phase": "Main",
+            "orders": {
+                "FRA: F bre -> eng": "Succeeds",
+                "FRA: A pic -> bel": "Succeeds",
+                "FRA: A bur Supports A pic -> bel": null,
+                "FRA: F mao Supports F bre -> eng": null,
+                "ENG: F eng convoys pic -> bel": null,
+                "ENG: A bel -> pic": "Fails"
+            }
+        },
+        {
+            "name": "t6g05_swapping_with_intent",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.5",
+            "phase": "Main",
+            "orders": {
+                "ITA: A rom -> apu": "Succeeds",
+                "ITA: F tys convoys apu -> rom": null,
+                "TUR: A apu -> rom": "Succeeds",
+                "TUR: F ion convoys apu -> rom": null
+            }
+        },
+        {
+            "name": "t6g06_swapping_with_unintended_intent",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.6",
+            "phase": "Main",
+            "orders": {
+                "ENG: A lvp -> edi": "Succeeds",
+                "ENG: F eng convoys lvp -> edi": null,
+                "GER: A edi -> lvp": "Succeeds",
+                "FRA: F iri Hold": null,
+                "FRA: F nth Hold": null,
+                "RUS: F nwg convoys lvp -> edi": null,
+                "RUS: F nao convoys lvp -> edi": null
+            }
+        },
+        {
+            "name": "t6g07_swapping_with_illegal_intent",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.7",
+            "phase": "Main",
+            "orders": {
+                "ENG: F ska convoys swe -> nwy": null,
+                "ENG: F nwy -> swe": "Succeeds",
+                "RUS: A swe -> nwy": "Succeeds",
+                "RUS: F bot convoys swe -> nwy": null
+            }
+        },
+        {
+            "name": "t6g08_explicit_convoy_that_isnt_there",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.8",
+            "phase": "Main",
+            "orders": {
+                "FRA: A bel -> hol via Convoy": "Fails",
+                "ENG: F nth -> hel": "Succeeds",
+                "ENG: A hol -> kie": "Succeeds"
+            }
+        },
+        {
+            "name": "t6g09_swapped_or_dislodged",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.9",
+            "phase": "Main",
+            "orders": {
+                "ENG: A nwy -> swe": "Succeeds",
+                "ENG: F ska convoys nwy -> swe": null,
+                "ENG: F fin Supports A nwy -> swe": null,
+                "RUS: A swe -> nwy": "Succeeds"
+            }
+        },
+        {
+            "name": "t6g10_swapped_or_an_head_to_head_battle",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.10",
+            "phase": "Main",
+            "orders": {
+                "ENG: A nwy -> swe via Convoy": "Succeeds",
+                "ENG: F den Supports A nwy -> swe": null,
+                "ENG: F fin Supports A nwy -> swe": null,
+                "GER: F ska convoys nwy -> swe": null,
+                "RUS: A swe -> nwy": "Fails",
+                "RUS: F bar supports A swe -> nwy": null,
+                "FRA: F nwg -> nwy": "Fails",
+                "FRA: F nth Supports F nwg -> nwy": null
+            }
+        },
+        {
+            "name": "t6g11_a_convoy_to_an_adjacent_place_with_a_paradox",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.11",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nwy Supports F nth -> ska": null,
+                "ENG: F nth -> ska": "Fails",
+                "RUS: A swe -> nwy": "Succeeds",
+                "RUS: F ska convoys swe -> nwy": null,
+                "RUS: F bar Supports A swe -> nwy": null
+            }
+        },
+        {
+            "name": "t6g11_variant_an_explicit_convoy_to_an_adjacent_place_with_a_paradox",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.11",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nwy Supports F nth -> ska": null,
+                "ENG: F nth -> ska": "Succeeds",
+                "RUS: A swe -> nwy via Convoy": "Fails",
+                "RUS: F ska convoys swe -> nwy": null,
+                "RUS: F bar Supports A swe -> nwy": null
+            }
+        },
+        {
+            "name": "t6g12_swapping_two_units_with_two_convoys",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.12",
+            "phase": "Main",
+            "orders": {
+                "ENG: A lvp -> edi via Convoy": "Succeeds",
+                "ENG: F nao convoys lvp -> edi": null,
+                "ENG: F nwg convoys lvp -> edi": null,
+                "GER: A edi -> lvp via Convoy": "Succeeds",
+                "GER: F nth convoys edi -> lvp": null,
+                "GER: F eng convoys edi -> lvp": null,
+                "GER: F iri convoys edi -> lvp": null
+            }
+        },
+        {
+            "name": "t6g13_support_cut_on_attack_on_itself_via_convoy",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.13",
+            "phase": "Main",
+            "orders": {
+                "AUS: F adr convoys tri -> ven": null,
+                "AUS: A tri -> ven via Convoy": "Fails",
+                "ITA: A ven Supports F alb -> tri": null,
+                "ITA: F alb -> tri": "Succeeds"
+            }
+        },
+        {
+            "name": "t6g14_bounce_by_convoy_to_adjacent_place",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.14",
+            "phase": "Main",
+            "orders": {
+                "ENG: A nwy -> swe": "Succeeds",
+                "ENG: F den Supports A nwy -> swe": null,
+                "ENG: F fin Supports A nwy -> swe": null,
+                "FRA: F nwg -> nwy": "Fails",
+                "FRA: F nth Supports F nwg -> nwy": null,
+                "GER: F ska convoys swe -> nwy": null,
+                "RUS: A swe -> nwy via Convoy": "Fails",
+                "RUS: F bar Supports A swe -> nwy": null
+            }
+        },
+        {
+            "name": "t6g15_bounce_and_dislodge_with_double_convoy",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.15",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nth convoys lon -> bel": null,
+                "ENG: A hol Supports A lon -> bel": null,
+                "ENG: A yor -> lon": "Fails",
+                "ENG: A lon -> bel via Convoy": null,
+                "FRA: F eng convoys bel -> lon": null,
+                "FRA: A bel -> lon via Convoy": null
+            }
+        },
+        {
+            "name": "t6g16_the_two_unit_in_one_area_bug_moving_by_convoy",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.16",
+            "phase": "Main",
+            "orders": {
+                "ENG: A nwy -> swe": "Succeeds",
+                "ENG: A den Supports A nwy -> swe": null,
+                "ENG: F bal Supports A nwy -> swe": null,
+                "ENG: F nth -> nwy": "Fails",
+                "RUS: A swe -> nwy via Convoy": "Succeeds",
+                "RUS: F ska convoys swe -> nwy": null,
+                "RUS: F nwg Supports A swe -> nwy": null
+            }
+        },
+        {
+            "name": "t6g17_the_two_unit_in_one_area_bug_moving_over_land",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.17",
+            "phase": "Main",
+            "orders": {
+                "ENG: A nwy -> swe via Convoy": "Succeeds",
+                "ENG: A den Supports A nwy -> swe": null,
+                "ENG: F bal Supports A nwy -> swe": null,
+                "ENG: F ska convoys nwy -> swe": null,
+                "ENG: F nth -> nwy": "Fails",
+                "RUS: A swe -> nwy": "Succeeds",
+                "RUS: F nwg Supports A swe -> nwy": null
+            }
+        },
+        {
+            "name": "t6g18_the_two_unit_in_one_area_bug_with_double_convoy",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.18",
+            "phase": "Main",
+            "orders": {
+                "ENG: F nth convoys lon -> bel": null,
+                "ENG: A hol Supports A lon -> bel": null,
+                "ENG: A yor -> lon": "Fails",
+                "ENG: A lon -> bel": "Succeeds",
+                "ENG: A ruh Supports A lon -> bel": null,
+                "FRA: F eng convoys bel -> lon": null,
+                "FRA: A bel -> lon": "Succeeds",
+                "FRA: A wal Supports A bel -> lon": null
+            }
+        },
+        {
+            "name": "t6g19_swapping_with_intent_of_unnecessary_convoy",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.19",
+            "todo": "Test marked with should_panic in Rust implementation",
+            "orders": {
+                "FRA: A mar -> spa": "Fails",
+                "FRA: F wes convoys mar -> spa": null,
+                "ITA: F lyo convoys mar -> spa": null,
+                "ITA: A spa -> mar": "Fails"
+            }
+        },
+        {
+            "name": "t6g20_explicit_convoy_to_adjacent_province_disrupted",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.G.20",
+            "phase": "Main",
+            "orders": {
+                "FRA: F bre -> eng": "Succeeds",
+                "FRA: A pic -> bel via convoy": "Fails",
+                "FRA: A bur supports A pic -> bel": null,
+                "FRA: F mao supports F bre -> eng": null,
+                "ENG: F eng convoys pic -> bel": null
+            }
+        },
+        {
+            "name": "t6h01_no_supports_during_retreat",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.H.1",
+            "todo": "Test checks that support orders are illegal in retreat phase"
+        },
+        {
+            "name": "t6h02_no_supports_from_retreating_unit",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.H.2",
+            "todo": "Test checks that retreating units cannot give support"
+        },
+        {
+            "name": "t6h03_no_convoy_during_retreat",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.H.3",
+            "todo": "Test checks that convoy orders are illegal in retreat phase"
+        },
+        {
+            "name": "t6h04_no_other_moves_during_retreat",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.H.4",
+            "phase": "Retreat",
+            "preceding_main_phase": {
+                "orders": {
+                    "ENG: F nth Hold": "Succeeds",
+                    "ENG: A hol Hold": "Fails",
+                    "GER: F kie Supports A ruh -> hol": null,
+                    "GER: A ruh -> hol": "Succeeds"
+                }
+            },
+            "orders": {
+                "ENG: F nth -> nwg": "Fails",
+                "ENG: A hol -> bel": "Succeeds"
+            }
+        },
+        {
+            "name": "t6h05_a_unit_may_not_retreat_to_the_area_from_which_it_is_attacked",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.H.5",
+            "phase": "Retreat",
+            "preceding_main_phase": {
+                "orders": {
+                    "RUS: F con Supports F bla -> ank": null,
+                    "RUS: F bla -> ank": "Succeeds",
+                    "TUR: F ank Hold": "Fails"
+                }
+            },
+            "orders": {
+                "TUR: F ank -> bla": "Fails"
+            }
+        },
+        {
+            "name": "t6h06_unit_may_not_retreat_to_a_contested_area",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.H.6",
+            "phase": "Retreat",
+            "preceding_main_phase": {
+                "orders": {
+                    "AUS: A bud Supports A tri -> vie": null,
+                    "AUS: A tri -> vie": "Succeeds",
+                    "GER: A mun -> boh": "Fails",
+                    "GER: A sil -> boh": "Fails",
+                    "ITA: A vie Hold": "Fails"
+                }
+            },
+            "orders": {
+                "ITA: A vie -> boh": "Fails"
+            }
+        },
+        {
+            "name": "t6h07_multiple_retreat_to_same_area_will_disband_units",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.H.7",
+            "phase": "Retreat",
+            "preceding_main_phase": {
+                "orders": {
+                    "AUS: A bud Supports A tri -> vie": null,
+                    "AUS: A tri -> vie": "Succeeds",
+                    "GER: A mun Supports A sil -> boh": null,
+                    "GER: A sil -> boh": "Succeeds",
+                    "ITA: A vie Hold": "Fails",
+                    "ITA: A boh Hold": "Fails"
+                }
+            },
+            "orders": {
+                "ITA: A vie -> tyr": "Fails",
+                "ITA: A boh -> tyr": "Fails"
+            }
+        },
+        {
+            "name": "t6h08_triple_retreat_to_same_area_will_disband_units",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.H.8",
+            "phase": "Retreat",
+            "preceding_main_phase": {
+                "orders": {
+                    "ENG: A lvp -> edi": "Succeeds",
+                    "ENG: F yor Supports A lvp -> edi": null,
+                    "ENG: F nwy Hold": "Fails",
+                    "GER: A kie Supports A ruh -> hol": null,
+                    "GER: A ruh -> hol": "Succeeds",
+                    "RUS: F edi Hold": "Fails",
+                    "RUS: A swe Supports A fin -> nwy": null,
+                    "RUS: A fin -> nwy": "Succeeds",
+                    "RUS: F hol Hold": "Fails"
+                }
+            },
+            "orders": {
+                "ENG: F nwy -> nth": "Fails",
+                "RUS: F edi -> nth": "Fails",
+                "RUS: F hol -> nth": "Fails"
+            }
+        },
+        {
+            "name": "t6h09_dislodged_unit_will_not_make_attackers_area_contested",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.H.9",
+            "phase": "Retreat",
+            "preceding_main_phase": {
+                "orders": {
+                    "ENG: F hel -> kie": "Succeeds",
+                    "ENG: F den Supports F hel -> kie": null,
+                    "GER: A ber -> pru": "Succeeds",
+                    "GER: F kie Hold": "Fails",
+                    "GER: A sil Supports A ber -> pru": null,
+                    "RUS: A pru -> ber": "Fails"
+                }
+            },
+            "orders": {
+                "GER: F kie -> ber": "Succeeds"
+            }
+        },
+        {
+            "name": "t6h10_not_retreating_to_attacker_does_not_mean_contested",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.H.10",
+            "phase": "Retreat",
+            "preceding_main_phase": {
+                "orders": {
+                    "ENG: A kie Hold": "Fails",
+                    "GER: A ber -> kie": "Succeeds",
+                    "GER: A mun Supports A ber -> kie": null,
+                    "GER: A pru Hold": "Fails",
+                    "RUS: A war -> pru": "Succeeds",
+                    "RUS: A sil Supports A war -> pru": null
+                }
+            },
+            "orders": {
+                "ENG: A kie -> ber": "Fails",
+                "GER: A pru -> ber": "Succeeds"
+            }
+        },
+        {
+            "name": "t6h11_retreat_when_dislodged_by_adjacent_convoy",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.H.11",
+            "phase": "Retreat",
+            "preceding_main_phase": {
+                "orders": {
+                    "FRA: A gas -> mar via Convoy": "Succeeds",
+                    "FRA: A bur Supports A gas -> mar": null,
+                    "FRA: F mao convoys gas -> mar": null,
+                    "FRA: F wes convoys gas -> mar": null,
+                    "FRA: F lyo convoys gas -> mar": null,
+                    "ITA: A mar Hold": "Fails"
+                }
+            },
+            "orders": {
+                "ITA: A mar -> gas": "Succeeds"
+            }
+        },
+        {
+            "name": "t6h12_retreat_when_dislodged_by_adjacent_convoy_while_trying_to_do_the_same",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.H.12",
+            "phase": "Retreat",
+            "preceding_main_phase": {
+                "orders": {
+                    "ENG: A lvp -> edi via Convoy": "Fails",
+                    "ENG: F iri convoys lvp -> edi": null,
+                    "ENG: F eng convoys lvp -> edi": null,
+                    "ENG: F nth convoys lvp -> edi": null,
+                    "FRA: F bre -> eng": null,
+                    "FRA: F mao Supports F bre -> eng": null,
+                    "RUS: A edi -> lvp via Convoy": "Succeeds",
+                    "RUS: F nwg convoys edi -> lvp": null,
+                    "RUS: F nao convoys edi -> lvp": null,
+                    "RUS: A cly Supports A edi -> lvp": null
+                }
+            },
+            "orders": {
+                "ENG: A lvp -> edi": "Succeeds"
+            }
+        },
+        {
+            "name": "t6h13_no_retreat_with_convoy_in_main_phase",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.H.13",
+            "phase": "Retreat",
+            "preceding_main_phase": {
+                "orders": {
+                    "ENG: A pic Hold": "Fails",
+                    "ENG: F eng convoys pic -> lon": null,
+                    "FRA: A par -> pic": "Succeeds",
+                    "FRA: A bre Supports A par -> pic": null
+                }
+            },
+            "orders": {
+                "ENG: A pic -> lon": "Fails"
+            }
+        },
+        {
+            "name": "t6h14_no_retreat_with_support_in_main_phase",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.H.14",
+            "phase": "Retreat",
+            "preceding_main_phase": {
+                "orders": {
+                    "ENG: A pic Hold": "Fails",
+                    "ENG: F eng Supports A pic -> bel": null,
+                    "FRA: A par -> pic": "Succeeds",
+                    "FRA: A bre Supports A par -> pic": null,
+                    "FRA: A bur Hold": "Fails",
+                    "GER: A mun Supports A mar -> bur": null,
+                    "GER: A mar -> bur": "Succeeds"
+                }
+            },
+            "orders": {
+                "ENG: A pic -> bel": "Fails",
+                "FRA: A bur -> bel": "Fails"
+            }
+        },
+        {
+            "name": "t6h15_no_coastal_crawl_in_retreat",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.H.15",
+            "phase": "Retreat",
+            "preceding_main_phase": {
+                "orders": {
+                    "ENG: F por Hold": "Fails",
+                    "FRA: F spa(sc) -> por": "Succeeds",
+                    "FRA: F mao Supports F spa(sc) -> por": null
+                }
+            },
+            "orders": {
+                "ENG: F por -> spa(nc)": "Fails"
+            }
+        },
+        {
+            "name": "t6h16_contested_for_both_coasts",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.H.16",
+            "phase": "Retreat",
+            "preceding_main_phase": {
+                "orders": {
+                    "FRA: F mao -> spa(nc)": "Fails",
+                    "FRA: F gas -> spa(nc)": "Fails",
+                    "FRA: F wes Hold": "Fails",
+                    "ITA: F tun Supports F tys -> wes": null,
+                    "ITA: F tys -> wes": "Succeeds"
+                }
+            },
+            "orders": {
+                "FRA: F wes -> spa(sc)": "Fails"
+            }
+        },
+        {
+            "name": "t6i01_too_many_build_orders",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.I.1",
+            "phase": "Build",
+            "starting_state": ["GER: F den", "GER: A ruh", "GER: A pru"],
+            "orders": {
+                "GER: A war build": "Fails",
+                "GER: A ber build": "Succeeds",
+                "GER: A mun build": "Fails"
+            }
+        },
+        {
+            "name": "t6i02_fleets_can_not_be_build_in_land_areas",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.I.2",
+            "phase": "Build",
+            "orders": {
+                "RUS: F mos build": "Fails"
+            }
+        },
+        {
+            "name": "t6i03_supply_center_must_be_empty_for_building",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.I.3",
+            "phase": "Build",
+            "starting_state": ["GER: A ber"],
+            "orders": {
+                "GER: A ber build": "Fails"
+            }
+        },
+        {
+            "name": "t6i04_both_coasts_must_be_empty_for_building",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.I.4",
+            "phase": "Build",
+            "starting_state": ["RUS: F stp(sc)"],
+            "orders": {
+                "RUS: F stp(nc) build": "Fails"
+            }
+        },
+        {
+            "name": "t6i05_building_in_home_supply_center_that_is_not_owned",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.I.5",
+            "phase": "Build",
+            "occupiers": {
+                "ber": "RUS"
+            },
+            "orders": {
+                "GER: A ber build": "Fails"
+            }
+        },
+        {
+            "name": "t6i06_building_in_owned_supply_center_that_is_not_a_home_supply_center",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.I.6",
+            "phase": "Build",
+            "occupiers": {
+                "war": "GER"
+            },
+            "orders": {
+                "GER: A war build": "Fails"
+            }
+        },
+        {
+            "name": "t6i07_only_one_build_in_a_home_supply_center",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.I.7",
+            "phase": "Build",
+            "starting_state": ["RUS: F sev", "RUS: F stp(nc)"],
+            "orders": {
+                "RUS: A mos build": "Succeeds",
+                "RUS: A war build": "Succeeds"
+            }
+        },
+        {
+            "name": "t6j01_too_many_remove_orders",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.J.1",
+            "phase": "Build",
+            "occupiers": {
+                "bre": "ENG",
+                "mar": "ITA"
+            },
+            "starting_state": ["FRA: A pic", "FRA: A par"],
+            "orders": {
+                "FRA: F lyo disband": "Fails",
+                "FRA: A pic disband": "Succeeds",
+                "FRA: A par disband": "Fails"
+            }
+        },
+        {
+            "name": "t6j02_removing_the_same_unit_twice",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.J.2",
+            "phase": "Build",
+            "starting_state": [
+                "ENG: F bre",
+                "ITA: A mar",
+                "FRA: A par",
+                "FRA: F lyo",
+                "FRA: A ruh"
+            ],
+            "orders": {
+                "FRA: A par disband": "Succeeds"
+            }
+        },
+        {
+            "name": "t6j03_civil_disorder_two_armies_with_different_distance",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.J.3",
+            "phase": "Build",
+            "occupiers": {
+                "war": "GER",
+                "mos": "GER",
+                "sev": "TUR"
+            },
+            "starting_state": ["RUS: A lvn", "RUS: A pru"],
+            "orders": {},
+            "civil_disorder": ["RUS: A pru"]
+        },
+        {
+            "name": "t6j04_civil_disorder_two_armies_with_equal_distance",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.J.4",
+            "phase": "Build",
+            "occupiers": {
+                "stp": "ENG",
+                "war": "GER",
+                "sev": "TUR"
+            },
+            "starting_state": ["RUS: A lvn", "RUS: A ukr"],
+            "orders": {},
+            "civil_disorder": ["RUS: A lvn"]
+        },
+        {
+            "name": "t6j05_civil_disorder_two_fleets_with_different_distance",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.J.5",
+            "phase": "Build",
+            "occupiers": {
+                "mos": "ENG",
+                "war": "GER",
+                "sev": "TUR"
+            },
+            "starting_state": ["RUS: F ska", "RUS: F nao"],
+            "orders": {},
+            "civil_disorder": ["RUS: F nao"]
+        },
+        {
+            "name": "t6j06_civil_disorder_two_fleets_with_equal_distance",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.J.6",
+            "phase": "Build",
+            "occupiers": {
+                "stp": "ENG",
+                "mos": "ENG",
+                "war": "GER",
+                "sev": "TUR",
+                "mun": "RUS"
+            },
+            "starting_state": ["RUS: F bot", "RUS: F nth"],
+            "orders": {},
+            "civil_disorder": ["RUS: F bot"]
+        },
+        {
+            "name": "t6j07_civil_disorder_two_fleets_and_army_with_equal_distance",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.J.7",
+            "phase": "Build",
+            "occupiers": {
+                "mos": "ENG",
+                "sev": "TUR"
+            },
+            "starting_state": ["RUS: A boh", "RUS: F ska", "RUS: F nth"],
+            "orders": {},
+            "civil_disorder": ["RUS: F nth"]
+        },
+        {
+            "name": "t6j08_civil_disorder_a_fleet_with_shorter_distance_then_the_army",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.J.8",
+            "phase": "Build",
+            "occupiers": {
+                "stp": "ENG",
+                "mos": "ENG",
+                "sev": "TUR"
+            },
+            "starting_state": ["RUS: A tyr", "RUS: F bal"],
+            "orders": {},
+            "civil_disorder": ["RUS: A tyr"]
+        },
+        {
+            "name": "t6j09_civil_disorder_must_be_counted_from_both_coasts",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.J.9",
+            "phase": "Build",
+            "occupiers": {
+                "war": "GER",
+                "mos": "ENG"
+            },
+            "starting_state": ["RUS: A alb", "RUS: A sev", "RUS: F bal"],
+            "orders": {},
+            "civil_disorder": ["RUS: A alb"]
+        },
+        {
+            "name": "t6j09_civil_disorder_must_be_counted_from_both_coasts_second_scenario",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.J.9",
+            "phase": "Build",
+            "occupiers": {
+                "war": "GER",
+                "mos": "ENG"
+            },
+            "starting_state": ["RUS: A alb", "RUS: A sev", "RUS: F ska"],
+            "orders": {},
+            "civil_disorder": ["RUS: F ska"]
+        },
+        {
+            "name": "t6j10_civil_disorder_counting_convoying_distance",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.J.10",
+            "phase": "Build",
+            "occupiers": {
+                "ven": "AUS",
+                "rom": "FRA"
+            },
+            "starting_state": ["ITA: A pie", "ITA: A alb"],
+            "orders": {},
+            "civil_disorder": ["ITA: A pie"]
+        },
+        {
+            "name": "t6j11_distance_to_owned_supply_center",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.J.11",
+            "phase": "Build",
+            "occupiers": {
+                "ven": "AUS",
+                "rom": "FRA",
+                "nap": "AUS"
+            },
+            "starting_state": ["ITA: A war", "ITA: A tus"],
+            "orders": {},
+            "civil_disorder": ["ITA: A tus"]
+        }
+    ]
+}

--- a/json_tests/src/case.rs
+++ b/json_tests/src/case.rs
@@ -1,0 +1,613 @@
+//! Types for declaring and running test cases of a Diplomacy adjudicator.
+
+use std::fmt;
+
+use diplomacy::{
+    geo::RegionKey,
+    judge::{MappedBuildOrder, MappedMainOrder, MappedRetreatOrder, OrderState},
+    Nation, UnitPosition,
+};
+use indexmap::IndexMap;
+
+use crate::MapKey;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
+pub struct Cases<T> {
+    pub cases: Vec<T>,
+}
+
+pub trait DidPass {
+    /// Returns `true` if the test case passed, meaning all expected outcomes matched the actual outcomes.
+    fn did_pass(&self) -> bool;
+}
+
+pub mod main {
+    use diplomacy::{
+        geo,
+        judge::{OrderOutcome, Outcome, Rulebook, Submission},
+    };
+
+    use crate::{with_map_key, OrderOutcomeWithState};
+
+    use super::*;
+
+    #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+    #[non_exhaustive]
+    pub struct TestCase {
+        /// Unit locations at the start of the test.
+        ///
+        /// If `None`, the test will infer the starting positions from the orders.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub starting_state: Option<Vec<MapKey<UnitPosition<'static, RegionKey>>>>,
+        #[serde(with = "with_map_key")]
+        pub orders: IndexMap<MappedMainOrder, Option<OrderState>>,
+    }
+
+    impl TestCase {
+        fn starting_state(&self) -> Option<Vec<UnitPosition<'static, RegionKey>>> {
+            self.starting_state
+                .as_ref()
+                .map(|positions| positions.iter().cloned().map(MapKey::into_inner).collect())
+        }
+
+        pub fn run(&self) -> TestResult {
+            let submission = self.to_submission();
+            self.to_test_result(&submission.adjudicate(Rulebook))
+        }
+
+        pub fn to_submission<'a>(&'a self) -> Submission<'a> {
+            let orders = self.orders.keys().cloned().collect();
+            match self.starting_state() {
+                Some(state) => Submission::new(geo::standard_map(), &state, orders),
+                None => Submission::with_inferred_state(geo::standard_map(), orders),
+            }
+        }
+
+        pub fn to_test_result(&self, outcome: &Outcome<'_, Rulebook>) -> TestResult {
+            TestResult {
+                outcomes: outcome
+                    .all_orders_with_outcomes()
+                    .map(|(order, outcome)| {
+                        (
+                            order.clone(),
+                            OrderOutcomeWithState::new(outcome.map_order(|o| MapKey(o.clone()))),
+                        )
+                    })
+                    .collect(),
+                mismatches: self
+                    .orders
+                    .iter()
+                    .filter_map(|(order, expected)| {
+                        let expected = (*expected)?;
+                        let order_outcome = *outcome
+                            .get(order)
+                            .expect("All orders should be present in the outcome");
+                        if expected == order_outcome.into() {
+                            None
+                        } else {
+                            Some(MapKey(order.clone()))
+                        }
+                    })
+                    .collect(),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct TestResult {
+        #[serde(with = "with_map_key")]
+        outcomes:
+            IndexMap<MappedMainOrder, OrderOutcomeWithState<OrderOutcome<MapKey<MappedMainOrder>>>>,
+        mismatches: Vec<MapKey<MappedMainOrder>>,
+    }
+
+    impl DidPass for TestResult {
+        fn did_pass(&self) -> bool {
+            self.mismatches.is_empty()
+        }
+    }
+}
+
+pub mod retreat {
+    use diplomacy::judge::{
+        retreat::{Context, OrderOutcome},
+        Rulebook,
+    };
+
+    use crate::{with_map_key, OrderOutcomeWithState};
+
+    use super::*;
+
+    #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+    #[non_exhaustive]
+    pub struct TestCase {
+        pub preceding_main_phase: main::TestCase,
+        #[serde(with = "with_map_key")]
+        pub orders: IndexMap<MappedRetreatOrder, Option<OrderState>>,
+    }
+
+    impl TestCase {
+        pub fn run(&self) -> TestResult {
+            // First, adjudicate the preceding main phase to set up the retreat phase.
+            let main_phase = self.preceding_main_phase.to_submission();
+            let main_phase_outcome = main_phase.adjudicate(Rulebook);
+            let main_phase_result = self
+                .preceding_main_phase
+                .to_test_result(&main_phase_outcome);
+
+            // If the main phase did not pass, then the retreat phase is not set up as expected.
+            if !main_phase_result.did_pass() {
+                return TestResult {
+                    preceding_main_phase: main_phase_result,
+                    outcomes: IndexMap::new(),
+                    mismatches: Vec::new(),
+                };
+            }
+
+            // Now start the actual test
+            let retreat_start = main_phase_outcome.to_retreat_start();
+            let ctx = Context::new(&retreat_start, self.orders.keys().cloned());
+            let outcome = ctx.resolve();
+
+            TestResult {
+                preceding_main_phase: main_phase_result,
+                outcomes: outcome
+                    .order_outcomes()
+                    .map(|(order, outcome)| {
+                        (
+                            order.clone(),
+                            OrderOutcomeWithState::new(outcome.map_order(|o| MapKey(o.clone()))),
+                        )
+                    })
+                    .collect(),
+                mismatches: self
+                    .orders
+                    .iter()
+                    .filter_map(|(order, expectation)| Some((order, (*expectation)?)))
+                    .filter_map(|(order, expected)| {
+                        let order_outcome =
+                            *outcome.get(order).expect("All orders should be present");
+                        if expected == order_outcome.into() {
+                            None
+                        } else {
+                            Some(MapKey(order.clone()))
+                        }
+                    })
+                    .collect(),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct TestResult {
+        preceding_main_phase: main::TestResult,
+        #[serde(with = "with_map_key")]
+        outcomes: IndexMap<
+            MappedRetreatOrder,
+            OrderOutcomeWithState<OrderOutcome<MapKey<MappedRetreatOrder>>>,
+        >,
+        mismatches: Vec<MapKey<MappedRetreatOrder>>,
+    }
+
+    impl DidPass for TestResult {
+        fn did_pass(&self) -> bool {
+            self.preceding_main_phase.did_pass() && self.mismatches.is_empty()
+        }
+    }
+}
+
+pub mod build {
+    use std::collections::{HashMap, HashSet};
+
+    use crate::{with_map_key, OrderOutcomeWithState};
+
+    use super::*;
+    use diplomacy::{
+        geo::{self, ProvinceKey},
+        judge::build::{to_initial_ownerships, OrderOutcome, WorldState},
+        UnitType,
+    };
+
+    #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+    #[non_exhaustive]
+    pub struct TestCase {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub occupiers: Option<IndexMap<ProvinceKey, Nation>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub starting_state: Option<Vec<MapKey<UnitPosition<'static, RegionKey>>>>,
+        #[serde(with = "with_map_key")]
+        pub orders: IndexMap<MappedBuildOrder, Option<OrderState>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub civil_disorder: Option<Vec<MapKey<UnitPosition<'static, RegionKey>>>>,
+    }
+
+    impl TestCase {
+        pub fn run(&self) -> TestResult {
+            let world = World::from(self);
+            let last_time = to_initial_ownerships(geo::standard_map());
+            let ctx = diplomacy::judge::build::Context::new(
+                geo::standard_map(),
+                &last_time,
+                &world,
+                self.orders.keys().cloned(),
+            );
+
+            let outcome = ctx.resolve();
+
+            let civil_disorder: Vec<_> = outcome
+                .to_civil_disorder()
+                .into_iter()
+                .map(MapKey)
+                .collect();
+
+            TestResult {
+                outcomes: outcome
+                    .order_outcomes()
+                    .map(|(order, outcome)| (order.clone(), OrderOutcomeWithState::new(*outcome)))
+                    .collect(),
+                mismatches: self
+                    .orders
+                    .iter()
+                    .filter_map(|(order, expectation)| Some((order, (*expectation)?)))
+                    .filter_map(|(order, expected)| {
+                        let order_outcome =
+                            *outcome.get(order).expect("All orders should be present");
+                        if expected == order_outcome.into() {
+                            None
+                        } else {
+                            Some(order.clone().into())
+                        }
+                    })
+                    .chain(self.civil_disorder.iter().flatten().filter_map(|pos| {
+                        // Any expected civil disorder positions that did not materialize are mismatches.
+                        // Tests are not required to specify all civil disorder positions, so the
+                        // reverse is not true.
+                        (!civil_disorder.contains(pos))
+                            .then_some(pos.clone())
+                            .map(Mismatch::from)
+                    }))
+                    .collect(),
+                civil_disorder,
+            }
+        }
+    }
+
+    struct World {
+        nations: HashSet<Nation>,
+        occupiers: HashMap<ProvinceKey, Nation>,
+        units: HashMap<Nation, HashSet<(UnitType, RegionKey)>>,
+    }
+
+    impl From<&'_ TestCase> for World {
+        fn from(value: &'_ TestCase) -> Self {
+            let mut nations = HashSet::new();
+            let mut occupiers = HashMap::new();
+            let mut units = HashMap::<Nation, HashSet<(UnitType, RegionKey)>>::new();
+
+            if let Some(occ) = &value.occupiers {
+                nations.extend(occ.values().cloned());
+                for (province, nation) in occ {
+                    occupiers.insert(province.clone(), nation.clone());
+                }
+            }
+
+            if let Some(unit_locations) = &value.starting_state {
+                nations.extend(unit_locations.iter().map(|pos| pos.nation().clone()));
+                for pos in unit_locations {
+                    units
+                        .entry(pos.nation().clone())
+                        .or_default()
+                        .insert((pos.unit.unit_type(), pos.region.clone()));
+                    occupiers.insert(pos.region.province().clone(), pos.nation().clone());
+                }
+            }
+
+            Self {
+                nations,
+                occupiers,
+                units,
+            }
+        }
+    }
+
+    impl WorldState for World {
+        fn nations(&self) -> HashSet<&Nation> {
+            self.nations.iter().collect()
+        }
+
+        fn occupier(&self, province: &ProvinceKey) -> Option<&Nation> {
+            self.occupiers.get(province)
+        }
+
+        fn unit_count(&self, nation: &Nation) -> u8 {
+            self.units
+                .get(nation)
+                .map(|u| u.len())
+                .unwrap_or_default()
+                .try_into()
+                .unwrap()
+        }
+
+        fn units(&self, nation: &Nation) -> HashSet<(UnitType, RegionKey)> {
+            self.units.get(nation).cloned().unwrap_or_default()
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+    #[non_exhaustive]
+    pub enum Mismatch {
+        Order(MapKey<MappedBuildOrder>),
+        Unit(MapKey<UnitPosition<'static, RegionKey>>),
+    }
+
+    impl From<MappedBuildOrder> for Mismatch {
+        fn from(order: MappedBuildOrder) -> Self {
+            Mismatch::Order(MapKey(order))
+        }
+    }
+
+    impl From<MapKey<UnitPosition<'static, RegionKey>>> for Mismatch {
+        fn from(pos: MapKey<UnitPosition<'static, RegionKey>>) -> Self {
+            Mismatch::Unit(pos)
+        }
+    }
+
+    impl From<UnitPosition<'static, RegionKey>> for Mismatch {
+        fn from(pos: UnitPosition<'static, RegionKey>) -> Self {
+            Mismatch::Unit(MapKey(pos))
+        }
+    }
+
+    #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+    pub struct TestResult {
+        civil_disorder: Vec<MapKey<UnitPosition<'static, RegionKey>>>,
+        #[serde(with = "with_map_key")]
+        outcomes: IndexMap<MappedBuildOrder, OrderOutcomeWithState<OrderOutcome>>,
+        mismatches: Vec<Mismatch>,
+    }
+
+    impl DidPass for TestResult {
+        fn did_pass(&self) -> bool {
+            self.mismatches.is_empty()
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct TestCaseTodo {
+    #[serde(flatten)]
+    info: TestCaseInfo,
+    todo: String,
+}
+
+/// Either a runnable test case, or a todo item.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(untagged)]
+pub enum RawTestCase {
+    Todo(TestCaseTodo),
+    Case(TestCase),
+}
+
+impl RawTestCase {
+    pub fn info(&self) -> &TestCaseInfo {
+        match self {
+            RawTestCase::Todo(todo) => &todo.info,
+            RawTestCase::Case(case) => &case.info,
+        }
+    }
+
+    pub fn todo(&self) -> Option<&str> {
+        match self {
+            RawTestCase::Todo(todo) => Some(&todo.todo),
+            RawTestCase::Case(_) => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "phase")]
+pub enum TestCaseBody {
+    Main(main::TestCase),
+    Retreat(retreat::TestCase),
+    Build(build::TestCase),
+}
+
+impl TestCaseBody {
+    pub fn run(&self) -> TestResultBody {
+        match self {
+            TestCaseBody::Main(case) => TestResultBody::Main(case.run()),
+            TestCaseBody::Retreat(case) => TestResultBody::Retreat(case.run()),
+            TestCaseBody::Build(case) => TestResultBody::Build(case.run()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "phase")]
+pub enum TestResultBody {
+    Main(main::TestResult),
+    Retreat(retreat::TestResult),
+    Build(build::TestResult),
+}
+
+impl DidPass for TestResultBody {
+    fn did_pass(&self) -> bool {
+        match self {
+            TestResultBody::Main(result) => result.did_pass(),
+            TestResultBody::Retreat(result) => result.did_pass(),
+            TestResultBody::Build(result) => result.did_pass(),
+        }
+    }
+}
+
+/// Wrapper around a test result that adds a `did_pass` field for serialization.
+/// This avoids the need for clients to know how to check the pass/fail status themselves.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct TestResult<T> {
+    did_pass: bool,
+    #[serde(flatten)]
+    body: T,
+}
+
+impl<T: DidPass> TestResult<T> {
+    pub fn new(body: T) -> Self {
+        Self {
+            did_pass: body.did_pass(),
+            body,
+        }
+    }
+}
+
+impl<T> DidPass for TestResult<T> {
+    fn did_pass(&self) -> bool {
+        self.did_pass
+    }
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[non_exhaustive]
+pub struct TestCaseInfo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+impl fmt::Display for TestCaseInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.name
+                .as_ref()
+                .or(self.url.as_ref())
+                .map(|s| s.as_str())
+                .unwrap_or("Unnamed Test Case")
+        )
+    }
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct TestCase {
+    #[serde(flatten)]
+    pub info: TestCaseInfo,
+    #[serde(flatten)]
+    pub body: TestCaseBody,
+}
+
+impl TestCase {
+    pub fn run(&self) -> TestResult<TestResultBody> {
+        TestResult::new(self.body.run())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::case::Cases;
+
+    use super::{DidPass, RawTestCase, TestCase};
+
+    #[test]
+    fn build_example() {
+        // DO NOT USE json! macro, as it does not preserve key order.
+        let test_case: TestCase = serde_json::from_str(
+            r#"{
+            "name": "t6i01_too_many_build_orders",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.I.1",
+            "phase": "Build",
+            "starting_state": ["GER: F den", "GER: A ruh", "GER: A pru"],
+            "orders": {
+                "GER: A war build": "Fails",
+                "GER: A ber build": "Succeeds",
+                "GER: A mun build": "Fails"
+            }
+        }"#,
+        )
+        .unwrap();
+
+        let result = test_case.run();
+        eprintln!("{}", serde_json::to_string_pretty(&result).unwrap());
+    }
+
+    #[test]
+    fn t6j01_too_many_remove_orders() {
+        // DO NOT USE json! macro, as it does not preserve key order.
+        let test_case: TestCase = serde_json::from_str(
+            r#"{
+            "name": "t6j01_too_many_remove_orders",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.J.1",
+            "phase": "Build",
+            "occupiers": {
+                "bre": "ENG",
+                "mar": "ITA"
+            },
+            "starting_state": ["FRA: A pic", "FRA: A par"],
+            "orders": {
+                "FRA: F lyo disband": "Fails",
+                "FRA: A pic disband": "Succeeds",
+                "FRA: A par disband": "Fails"
+            }
+        }"#,
+        )
+        .unwrap();
+
+        assert!(test_case.run().did_pass(), "Test case should pass");
+    }
+
+    #[test]
+    fn retreat_example() {
+        // DO NOT USE json! macro, as it does not preserve key order.
+        let test_case: TestCase = serde_json::from_str(
+            r#"{
+            "name": "t6h06_unit_may_not_retreat_to_a_contested_area",
+            "url": "https://webdiplomacy.net/doc/DATC_v3_0.html#6.H.6",
+            "phase": "Retreat",
+            "preceding_main_phase": {
+                "orders": {
+                    "AUS: A bud Supports A tri -> vie": null,
+                    "AUS: A tri -> vie": "Succeeds",
+                    "GER: A mun -> boh": "Fails",
+                    "GER: A sil -> boh": "Fails",
+                    "ITA: A vie Hold": "Fails"
+                }
+            },
+            "orders": {
+                "ITA: A vie -> boh": "Fails"
+            }
+        }"#,
+        )
+        .unwrap();
+        let result = test_case.run();
+        eprintln!("{}", serde_json::to_string_pretty(&result).unwrap());
+        assert!(result.did_pass(), "Test case should pass");
+    }
+
+    #[test]
+    fn reads_all() {
+        let test_cases: Vec<TestCase> =
+            serde_json::from_str::<Cases<RawTestCase>>(include_str!("../datc.json"))
+                .unwrap()
+                .cases
+                .into_iter()
+                .filter_map(|v| match v {
+                    RawTestCase::Case(test_case) => Some(test_case),
+                    RawTestCase::Todo(e) => {
+                        eprintln!("Skipping test case '{}'. {}", e.info, e.todo);
+                        None
+                    }
+                })
+                .collect();
+        for test in test_cases {
+            let result = test.run();
+            if !result.did_pass() {
+                eprintln!(
+                    "Test case '{}' failed with mismatches: {}\n{}",
+                    test.info,
+                    serde_json::to_string_pretty(&test.body).unwrap(),
+                    serde_json::to_string_pretty(&result).unwrap()
+                );
+            }
+        }
+    }
+}

--- a/json_tests/src/lib.rs
+++ b/json_tests/src/lib.rs
@@ -4,6 +4,13 @@
 //! The main crate does not have any direct need for [`serde_json`], so these
 //! tests are kept separately.
 
+pub mod case;
+mod map_key;
+mod outcome_with_state;
+
+pub use map_key::{with_map_key, MapKey};
+pub use outcome_with_state::OrderOutcomeWithState;
+
 #[cfg(test)]
 mod tests {
     use std::{fmt::Display, str::FromStr};

--- a/json_tests/src/map_key.rs
+++ b/json_tests/src/map_key.rs
@@ -1,0 +1,114 @@
+use std::{fmt, str::FromStr};
+
+use std::ops::Deref;
+
+use diplomacy::geo::Location;
+use diplomacy::Command;
+use serde_with::{DeserializeFromStr, SerializeDisplay};
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, SerializeDisplay, DeserializeFromStr,
+)]
+pub struct MapKey<O>(pub(crate) O);
+
+impl<O> MapKey<O> {
+    pub fn into_inner(self) -> O {
+        self.0
+    }
+}
+
+impl<O> Deref for MapKey<O> {
+    type Target = O;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<O: fmt::Display> fmt::Display for MapKey<O> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<O: FromStr> FromStr for MapKey<O> {
+    type Err = O::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse().map(Self)
+    }
+}
+
+impl<O: Command<L>, L: Location> Command<L> for MapKey<O> {
+    fn move_dest(&self) -> Option<&L> {
+        self.0.move_dest()
+    }
+}
+
+/// Provides serialization and deserialization for a map with keys that implement `Display` and `FromStr`.
+/// This is useful for JSON serialization where keys need to be strings.
+pub mod with_map_key {
+    use std::{fmt::Display, marker::PhantomData, str::FromStr};
+
+    use super::MapKey;
+    use serde::{
+        de::{Error, Visitor},
+        ser::SerializeMap,
+        Deserialize, Serialize, Serializer,
+    };
+
+    pub fn serialize<'a, S: Serializer, K: 'a + Serialize + Display, V: 'a + Serialize>(
+        value: impl IntoIterator<Item = (&'a K, &'a V)>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut s = serializer.serialize_map(None)?;
+        for (k, v) in value {
+            s.serialize_entry(&MapKey(k), &v)?;
+        }
+        s.end()
+    }
+
+    pub fn deserialize<'de, D, K, V, C>(deserializer: D) -> Result<C, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+        K: Deserialize<'de> + FromStr,
+        K::Err: Display,
+        V: Deserialize<'de>,
+        C: FromIterator<(K, V)>,
+    {
+        struct MapKeyVisitor<K, V, C>(PhantomData<(K, V, C)>);
+
+        impl<K, V, C> Default for MapKeyVisitor<K, V, C> {
+            fn default() -> Self {
+                MapKeyVisitor(PhantomData)
+            }
+        }
+
+        impl<'de, K, V, C> Visitor<'de> for MapKeyVisitor<K, V, C>
+        where
+            K: Deserialize<'de> + FromStr,
+            K::Err: Display,
+            V: Deserialize<'de>,
+            C: FromIterator<(K, V)>,
+        {
+            type Value = C;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, "a map with keys that implement Display and FromStr")
+            }
+
+            fn visit_map<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut entries: Vec<(K, V)> = vec![];
+                while let Some((key, value)) = access.next_entry::<String, V>()? {
+                    entries.push((FromStr::from_str(&key).map_err(A::Error::custom)?, value));
+                }
+                Ok(entries.into_iter().collect())
+            }
+        }
+
+        deserializer.deserialize_map(MapKeyVisitor::default())
+    }
+}

--- a/json_tests/src/outcome_with_state.rs
+++ b/json_tests/src/outcome_with_state.rs
@@ -1,0 +1,21 @@
+use diplomacy::judge::OrderState;
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct OrderOutcomeWithState<O> {
+    /// Whether the order succeeded.
+    succeeds: bool,
+    /// The specific outcome of the order.
+    outcome: O,
+}
+
+impl<O> OrderOutcomeWithState<O>
+where
+    for<'a> &'a O: Into<OrderState>,
+{
+    pub fn new(outcome: O) -> Self {
+        Self {
+            succeeds: bool::from((&outcome).into()),
+            outcome,
+        }
+    }
+}

--- a/json_tests/tests.schema.json
+++ b/json_tests/tests.schema.json
@@ -1,0 +1,146 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "properties": {
+        "cases": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/testCase"
+            }
+        }
+    },
+    "definitions": {
+        "testCase": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            },
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/mainPhase"
+                },
+                {
+                    "$ref": "#/definitions/retreatPhase"
+                },
+                {
+                    "$ref": "#/definitions/buildPhase"
+                },
+                {
+                    "$ref": "#/definitions/todoCase"
+                }
+            ],
+            "required": ["name", "url"]
+        },
+        "mainPhase": {
+            "properties": {
+                "phase": {
+                    "enum": ["Main"]
+                },
+                "starting_state": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/unitPosition"
+                    }
+                },
+                "orders": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[A-Z]{3}: [AF] .+$": {
+                            "enum": ["Succeeds", "Fails", null]
+                        }
+                    }
+                }
+            },
+            "required": ["phase", "orders"]
+        },
+        "retreatPhase": {
+            "properties": {
+                "phase": {
+                    "enum": ["Retreat"]
+                },
+                "preceding_main_phase": {
+                    "properties": {
+                        "starting_state": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/unitPosition"
+                            }
+                        },
+                        "orders": {
+                            "type": "object",
+                            "patternProperties": {
+                                "^[A-Z]{3}: [AF] .+$": {
+                                    "enum": ["Succeeds", "Fails", null]
+                                }
+                            }
+                        }
+                    },
+                    "required": ["orders"]
+                },
+                "orders": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[A-Z]{3}: [AF] .+$": {
+                            "enum": ["Succeeds", "Fails", null]
+                        }
+                    }
+                }
+            },
+            "required": ["phase", "preceding_main_phase", "orders"]
+        },
+        "buildPhase": {
+            "properties": {
+                "phase": {
+                    "enum": ["Build"]
+                },
+                "civil_disorder": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/unitPosition"
+                    },
+                    "description": "A list of units that are expected to disband in civil disorder."
+                },
+                "occupiers": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-z]{3}$": {
+                            "pattern": "^[A-Z]{3}$"
+                        }
+                    },
+                    "description": "A map of provinces to the nations that occupy them."
+                },
+                "starting_state": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/unitPosition"
+                    }
+                },
+                "orders": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[A-Z]{3}: [AF] .+$": {
+                            "type": ["string", "null"]
+                        }
+                    }
+                }
+            },
+            "required": ["phase", "orders"]
+        },
+        "todoCase": {
+            "properties": {
+                "todo": {
+                    "type": "string",
+                    "description": "A description of the test case that is yet to be implemented."
+                }
+            },
+            "required": ["todo"]
+        },
+        "unitPosition": {
+            "type": "string",
+            "pattern": "^[A-Z]{3}: [AF] [a-z()]+$"
+        }
+    }
+}


### PR DESCRIPTION
This supports visualization of tests, e.g. in a web application.

- Add JSON schema for tests
- Migrate existing tests from diplomacy/tests to JSON file